### PR TITLE
Azjol-Nerub Rewrite

### DIFF
--- a/data/sql/updates/db_world/2026_06_15_01.sql
+++ b/data/sql/updates/db_world/2026_06_15_01.sql
@@ -8,3 +8,8 @@ DELETE FROM smart_scripts WHERE entryorguid = 29064;
 DELETE FROM spell_script_names WHERE spell_id = 53035;
 DELETE FROM spell_script_names WHERE spell_id = 53036;
 DELETE FROM spell_script_names WHERE spell_id = 53037;
+
+UPDATE `creature_template` SET `AIName` = '', `ScriptName` = 'npc_watcher_narjil' WHERE `entry` = 28729;
+UPDATE `creature_template` SET `AIName` = '', `ScriptName` = 'npc_watcher_gashra' WHERE `entry` = 28730;
+UPDATE `creature_template` SET `AIName` = '', `ScriptName` = 'npc_watcher_silthik' WHERE `entry` = 28731;
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (28729, 28730, 28731);

--- a/data/sql/updates/db_world/2026_06_15_01.sql
+++ b/data/sql/updates/db_world/2026_06_15_01.sql
@@ -5,3 +5,7 @@ DELETE FROM smart_scripts WHERE entryorguid = 29063;
 DELETE FROM smart_scripts WHERE entryorguid = 29064;
 
 INSERT INTO spell_script_names (spell_id, ScriptName) VALUES (57731, 'spell_hadronox_web_grab');
+
+DELETE FROM spell_script_names WHERE spell_id = 53035;
+DELETE FROM spell_script_names WHERE spell_id = 53036;
+DELETE FROM spell_script_names WHERE spell_id = 53037;

--- a/data/sql/updates/db_world/2026_06_15_01.sql
+++ b/data/sql/updates/db_world/2026_06_15_01.sql
@@ -1,0 +1,7 @@
+UPDATE creature_template SET AIName = NULL, ScriptName = CASE entry WHEN 29062 THEN 'npc_anub_ar_champion' WHEN 29063 THEN 'npc_anub_ar_necromancer' WHEN 29064 THEN 'npc_anub_ar_cryptfiend' END WHERE entry IN (29062, 29063, 29064);
+
+DELETE FROM smart_scripts WHERE entryorguid = 29062;
+DELETE FROM smart_scripts WHERE entryorguid = 29063;
+DELETE FROM smart_scripts WHERE entryorguid = 29064;
+
+INSERT INTO spell_script_names (spell_id, ScriptName) VALUES (57731, 'spell_hadronox_web_grab');

--- a/data/sql/updates/db_world/2026_06_15_01.sql
+++ b/data/sql/updates/db_world/2026_06_15_01.sql
@@ -1,10 +1,9 @@
-UPDATE creature_template SET AIName = NULL, ScriptName = CASE entry WHEN 29062 THEN 'npc_anub_ar_champion' WHEN 29063 THEN 'npc_anub_ar_necromancer' WHEN 29064 THEN 'npc_anub_ar_cryptfiend' END WHERE entry IN (29062, 29063, 29064);
+UPDATE creature_template SET AIName = '', ScriptName = CASE entry WHEN 29062 THEN 'npc_anub_ar_champion' WHEN 29063 THEN 'npc_anub_ar_necromancer' WHEN 29064 THEN 'npc_anub_ar_cryptfiend' END WHERE entry IN (29062, 29063, 29064);
+UPDATE creature_template SET AIName = '', ScriptName = CASE entry WHEN 29117 THEN 'npc_anub_ar_champion' WHEN 29119 THEN 'npc_anub_ar_necromancer' WHEN 29118 THEN 'npc_anub_ar_cryptfiend' END WHERE entry IN (29117, 29119, 29118);
 
 DELETE FROM smart_scripts WHERE entryorguid = 29062;
 DELETE FROM smart_scripts WHERE entryorguid = 29063;
 DELETE FROM smart_scripts WHERE entryorguid = 29064;
-
-INSERT INTO spell_script_names (spell_id, ScriptName) VALUES (57731, 'spell_hadronox_web_grab');
 
 DELETE FROM spell_script_names WHERE spell_id = 53035;
 DELETE FROM spell_script_names WHERE spell_id = 53036;

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -92,6 +92,8 @@ class boss_anub_arak : public CreatureScript
                 _summonedMinions = false;
             }
 
+            GuidSet _pathingToCenter;
+
             void EnterEvadeMode(EvadeReason why) override
             {
                 me->DisableRotate(false);
@@ -135,12 +137,14 @@ class boss_anub_arak : public CreatureScript
             {
                 BossAI::Reset();
                 _summonedMinions = false;
+                _pathingToCenter.clear();
                 me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);
                 instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMED_START_EVENT);
 
                 ScheduleHealthCheckEvent({ 75, 50, 25 }, [&]{
                     Talk(SAY_SUBMERGE);
                     _summonedMinions = false;
+                    _pathingToCenter.clear();
                     DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
 
                     me->SetReactState(REACT_PASSIVE);
@@ -213,6 +217,35 @@ class boss_anub_arak : public CreatureScript
 
                 if (me->HasUnitState(UNIT_STATE_CASTING))
                     return;
+
+                if (!me->HasAura(SPELL_SUBMERGE) && me->HasAura(SPELL_SUBMERGE_IMMUNITY))
+                    me->RemoveAura(SPELL_SUBMERGE_IMMUNITY);
+
+                for (ObjectGuid guid : summons)
+                {
+                    Creature* summon = ObjectAccessor::GetCreature(*me, guid);
+                    if (!summon || !summon->IsAlive())
+                        continue;
+                    if (summon->IsTrigger() || summon->GetDistance(me) > 200.0f)
+                        continue;
+
+                    if (!summon->GetVictim() && summon->GetDistance(537.92f, 256.24f, 223.45f) > 10.0f)
+                    {
+                        summon->GetMotionMaster()->MovePoint(0, 537.92f + frand(-5.0f, 5.0f), 256.24f + frand(-5.0f, 5.0f), 223.45f);
+                        _pathingToCenter.insert(summon->GetGUID());
+                    }
+                    else if (!summon->GetVictim() && summon->GetPositionY() > 280.0f && !summon->isMoving())
+                    {
+                        summon->GetMotionMaster()->MovePoint(0, 537.92f + frand(-5.0f, 5.0f), 256.24f + frand(-5.0f, 5.0f), 223.45f);
+                        _pathingToCenter.insert(summon->GetGUID());
+                    }
+                    else if (summon->GetVictim() && _pathingToCenter.count(summon->GetGUID()))
+                    {
+                        _pathingToCenter.erase(summon->GetGUID());
+                        summon->GetMotionMaster()->Clear();
+                        summon->AI()->AttackStart(summon->GetVictim());
+                    }
+                }
 
                 switch (events.ExecuteEvent())
                 {

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -33,10 +33,10 @@ enum Spells
     SPELL_IMPALE_PERIODIC               = 53456,
     SPELL_EMERGE                        = 53500,
     SPELL_SUBMERGE                      = 53421,
-    SPELL_SELF_ROOT                     = 42716,
+    SPELL_SUBMERGE_SELF_ROOT            = 42716,
     SPELL_CLEAR_ALL_DEBUFFS             = 34098,
-    SPELL_IMMUNITY                      = 29230,
-    SPELL_INTERRUPT_SELF                = 68848,
+    SPELL_SUBMERGE_IMMUNITY             = 29230,
+    SPELL_ANUB_INTERRUPT_SELF           = 68848,
 
     SPELL_SUMMON_DARTER                 = 53599,
     SPELL_SUMMON_ASSASSIN               = 53610,
@@ -145,7 +145,7 @@ class boss_anub_arak : public CreatureScript
 
                     me->SetReactState(REACT_PASSIVE);
 
-                    if (Aura* immunity = me->AddAura(SPELL_IMMUNITY, me))
+                    if (Aura* immunity = me->AddAura(SPELL_SUBMERGE_IMMUNITY, me))
                         immunity->SetDuration(15000);
 
                     me->RemoveAura(SPELL_SUBMERGE);
@@ -231,7 +231,7 @@ class boss_anub_arak : public CreatureScript
                     case EVENT_POUND:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 10.0f))
                         {
-                            me->CastSpell(me, SPELL_SELF_ROOT, true);
+                            me->CastSpell(me, SPELL_SUBMERGE_SELF_ROOT, true);
                             me->DisableRotate(true);
                             me->SendMovementFlagUpdate();
                             events.ScheduleEvent(EVENT_ENABLE_ROTATE, 3300ms);
@@ -240,19 +240,19 @@ class boss_anub_arak : public CreatureScript
                         events.ScheduleEvent(EVENT_POUND, 18s);
                         break;
                     case EVENT_ENABLE_ROTATE:
-                        me->RemoveAurasDueToSpell(SPELL_SELF_ROOT);
+                        me->RemoveAurasDueToSpell(SPELL_SUBMERGE_SELF_ROOT);
                         me->DisableRotate(false);
                         break;
                     case EVENT_EMERGE:
                     {
                         me->m_Events.KillAllEvents(false);
                         
-                        me->RemoveAura(SPELL_IMMUNITY);
+                        me->RemoveAura(SPELL_SUBMERGE_IMMUNITY);
 
-                        if (Aura* root = me->AddAura(SPELL_SELF_ROOT, me))
+                        if (Aura* root = me->AddAura(SPELL_SUBMERGE_SELF_ROOT, me))
                             root->SetDuration(1500);
 
-                        DoCastSelf(SPELL_INTERRUPT_SELF, true);
+                        DoCastSelf(SPELL_ANUB_INTERRUPT_SELF, true);
 
                         me->RemoveAura(SPELL_IMPALE_PERIODIC);
                         me->RemoveAura(SPELL_SUBMERGE);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -151,7 +151,7 @@ class boss_anub_arak : public CreatureScript
                     me->RemoveAura(SPELL_SUBMERGE);
 
                     me->m_Events.AddEventAtOffset([this] {
-                        me->PerformEmote(374);
+                        me->HandleEmoteCommand(374);
                     }, 250ms);
 
                     me->m_Events.AddEventAtOffset([this] {
@@ -259,43 +259,43 @@ class boss_anub_arak : public CreatureScript
                         
                         // Sometimes the emote fails due to packet race conditions, so we fire it multiple times
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 50ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 100ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 150ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 200ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 250ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 300ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 350ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 400ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 450ms);
 
                         me->m_Events.AddEventAtOffset([this] {
-                            me->PerformEmote(449);
+                            me->HandleEmoteCommand(449);
                         }, 500ms);
 
                         me->m_Events.AddEventAtOffset([this] {

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -267,9 +267,9 @@ class boss_anub_arak : public CreatureScript
         }
 };
 
-class spell_azjol_nerub_carrion_beetels : public AuraScript
+class spell_azjol_nerub_carrion_beetles : public AuraScript
 {
-    PrepareAuraScript(spell_azjol_nerub_carrion_beetels)
+    PrepareAuraScript(spell_azjol_nerub_carrion_beetles)
 
     void HandleEffectPeriodic(AuraEffect const*  /*aurEff*/)
     {
@@ -280,7 +280,7 @@ class spell_azjol_nerub_carrion_beetels : public AuraScript
 
     void Register() override
     {
-        OnEffectPeriodic += AuraEffectPeriodicFn(spell_azjol_nerub_carrion_beetels::HandleEffectPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
+        OnEffectPeriodic += AuraEffectPeriodicFn(spell_azjol_nerub_carrion_beetles::HandleEffectPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
     }
 };
 
@@ -321,7 +321,7 @@ class spell_azjol_nerub_impale_summon : public SpellScript
 void AddSC_boss_anub_arak()
 {
     new boss_anub_arak();
-    RegisterSpellScript(spell_azjol_nerub_carrion_beetels);
+    RegisterSpellScript(spell_azjol_nerub_carrion_beetles);
     RegisterSpellScript(spell_azjol_nerub_pound);
     RegisterSpellScript(spell_azjol_nerub_impale_summon);
 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -256,47 +256,17 @@ class boss_anub_arak : public CreatureScript
 
                         me->RemoveAura(SPELL_IMPALE_PERIODIC);
                         me->RemoveAura(SPELL_SUBMERGE);
-                        
-                        // Sometimes the emote fails due to packet race conditions, so we fire it multiple times
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 50ms);
 
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 100ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 150ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 200ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 250ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 300ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 350ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 400ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 450ms);
-
-                        me->m_Events.AddEventAtOffset([this] {
-                            me->HandleEmoteCommand(449);
-                        }, 500ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 50ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 100ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 150ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 200ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 250ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 300ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 350ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 400ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 450ms);
+                        me->m_Events.AddEventAtOffset([this] { me->HandleEmoteCommand(449); }, 500ms);
 
                         me->m_Events.AddEventAtOffset([this] {
                             me->SetReactState(REACT_AGGRESSIVE);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -35,6 +35,8 @@ enum Spells
     SPELL_SUBMERGE                      = 53421,
     SPELL_SELF_ROOT                     = 42716,
     SPELL_CLEAR_ALL_DEBUFFS             = 34098,
+    SPELL_IMMUNITY                      = 29230,
+    SPELL_INTERRUPT_SELF                = 68848,
 
     SPELL_SUMMON_DARTER                 = 53599,
     SPELL_SUMMON_ASSASSIN               = 53610,
@@ -56,7 +58,7 @@ enum Misc
 {
     ACHIEV_TIMED_START_EVENT            = 20381,
 
-    EVENT_CARRION_BEETELS               = 1,
+    EVENT_CARRION_BEETLES               = 1,
     EVENT_LEECHING_SWARM                = 2,
     EVENT_IMPALE                        = 3,
     EVENT_POUND                         = 4,
@@ -93,6 +95,7 @@ class boss_anub_arak : public CreatureScript
             void EnterEvadeMode(EvadeReason why) override
             {
                 me->DisableRotate(false);
+                me->SetReactState(REACT_AGGRESSIVE);
                 BossAI::EnterEvadeMode(why);
             }
 
@@ -139,12 +142,26 @@ class boss_anub_arak : public CreatureScript
                     Talk(SAY_SUBMERGE);
                     _summonedMinions = false;
                     DoCastSelf(SPELL_CLEAR_ALL_DEBUFFS, true);
-                    DoCastSelf(SPELL_SUBMERGE, false);
+
+                    me->SetReactState(REACT_PASSIVE);
+
+                    if (Aura* immunity = me->AddAura(SPELL_IMMUNITY, me))
+                        immunity->SetDuration(15000);
+
+                    me->RemoveAura(SPELL_SUBMERGE);
+
+                    me->m_Events.AddEventAtOffset([this] {
+                        me->PerformEmote(374);
+                    }, 250ms);
+
+                    me->m_Events.AddEventAtOffset([this] {
+                        DoCastSelf(SPELL_SUBMERGE, false);
+                    }, 1700ms);
 
                     me->m_Events.AddEventAtOffset([this] {
                         me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                         DoCastSelf(SPELL_IMPALE_PERIODIC, true);
-                    }, 2s);
+                    }, 2000ms);
 
                     events.Reset();
                     events.ScheduleEvent(EVENT_EMERGE, 60s);
@@ -174,7 +191,7 @@ class boss_anub_arak : public CreatureScript
                 Talk(SAY_AGGRO);
                 instance->DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMED_START_EVENT);
 
-                events.ScheduleEvent(EVENT_CARRION_BEETELS, 6500ms);
+                events.ScheduleEvent(EVENT_CARRION_BEETLES, 6500ms);
                 events.ScheduleEvent(EVENT_LEECHING_SWARM, 20s);
                 events.ScheduleEvent(EVENT_POUND, 15s);
                 events.ScheduleEvent(EVENT_CLOSE_DOORS, 5s);
@@ -202,9 +219,9 @@ class boss_anub_arak : public CreatureScript
                     case EVENT_CLOSE_DOORS:
                         _JustEngagedWith();
                         break;
-                    case EVENT_CARRION_BEETELS:
+                    case EVENT_CARRION_BEETLES:
                         me->CastSpell(me, SPELL_CARRION_BEETLES, false);
-                        events.ScheduleEvent(EVENT_CARRION_BEETELS, 25s);
+                        events.ScheduleEvent(EVENT_CARRION_BEETLES, 25s);
                         break;
                     case EVENT_LEECHING_SWARM:
                         Talk(SAY_LOCUST);
@@ -227,14 +244,71 @@ class boss_anub_arak : public CreatureScript
                         me->DisableRotate(false);
                         break;
                     case EVENT_EMERGE:
-                        me->CastSpell(me, SPELL_EMERGE, true);
-                        me->RemoveAura(SPELL_SUBMERGE);
+                    {
+                        me->m_Events.KillAllEvents(false);
+                        
+                        me->RemoveAura(SPELL_IMMUNITY);
+
+                        if (Aura* root = me->AddAura(SPELL_SELF_ROOT, me))
+                            root->SetDuration(1500);
+
+                        DoCastSelf(SPELL_INTERRUPT_SELF, true);
+
                         me->RemoveAura(SPELL_IMPALE_PERIODIC);
+                        me->RemoveAura(SPELL_SUBMERGE);
+                        
+                        // Sometimes the emote fails due to packet race conditions, so we fire it multiple times
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 50ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 100ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 150ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 200ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 250ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 300ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 350ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 400ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 450ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->PerformEmote(449);
+                        }, 500ms);
+
+                        me->m_Events.AddEventAtOffset([this] {
+                            me->SetReactState(REACT_AGGRESSIVE);
+                        }, 1500ms);
+
+                        DoCastSelf(SPELL_EMERGE, true);
                         me->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);
-                        events.ScheduleEvent(EVENT_CARRION_BEETELS, 6500ms);
+                        events.ScheduleEvent(EVENT_CARRION_BEETLES, 6500ms);
                         events.ScheduleEvent(EVENT_LEECHING_SWARM, 20s);
                         events.ScheduleEvent(EVENT_POUND, 15s);
                         break;
+                    }
                     case EVENT_SUMMON_ASSASSINS:
                         SummonHelpers(509.32f, 247.42f, 239.48f, SPELL_SUMMON_ASSASSIN);
                         SummonHelpers(589.51f, 240.19f, 236.0f, SPELL_SUMMON_ASSASSIN);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -374,17 +374,23 @@ struct npc_hadronox_addAI : public ScriptedAI
             _chasingHadronox = false;
             _crusherPathStep = 0;
             me->GetMotionMaster()->Clear();
-            me->SetReactState(REACT_AGGRESSIVE);
             if (who->IsPlayer())
                 AttackStart(who);
-            ScheduleCombatEvents();
-
-            std::list<Creature*> crushers;
-            me->GetCreaturesWithEntryInRange(crushers, 10.0f, NPC_ANUB_AR_CRUSHER);
-            for (Creature* crusher : crushers)
-                if (crusher->IsAlive() && !crusher->IsInCombat())
-                    crusher->AI()->AttackStart(who);
         }
+    }
+    
+    void JustEngagedWith(Unit* who) override
+    {
+        me->SetReactState(REACT_AGGRESSIVE);
+        if (who->IsPlayer())
+            AttackStart(who);
+        ScheduleCombatEvents();
+
+        std::list<Creature*> crushers;
+        me->GetCreaturesWithEntryInRange(crushers, 10.0f, NPC_ANUB_AR_CRUSHER);
+        for (Creature* crusher : crushers)
+            if (crusher->IsAlive() && !crusher->IsInCombat())
+                crusher->AI()->AttackStart(who);
     }
 
     void JustEngagedWith(Unit* /*who*/) override {}

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -212,6 +212,7 @@ struct npc_hadronox_addAI : public ScriptedAI
 
     void Reset() override
     {
+        ReleaseSlot();
         _currentWaypoint = 0;
         _reachedHadronox = false;
         _attackedByPlayer = false;
@@ -223,7 +224,7 @@ struct npc_hadronox_addAI : public ScriptedAI
             IssueMove();
     }
 
-    void SetData(uint32 /*id*/, uint32 value) override
+    void SetData(uint32 id, uint32 value) override
     {
         if (id == 0)
         {
@@ -242,11 +243,6 @@ struct npc_hadronox_addAI : public ScriptedAI
             HadronoxAddSlots::Occupied[_reservedSlot] = false;
             _reservedSlot = -1;
         }
-    }
-
-    void JustDespawned() override
-    {
-        ReleaseSlot();
     }
 
     Creature* FindHadronox() const

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -24,6 +24,11 @@
 #include "SpellAuraEffects.h"
 #include "SpellScript.h"
 
+// Configs
+constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = true;  // Blizzlike is false
+constexpr bool CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER      = false; // true = on player entering gauntlet (y < 625), false = on crusher engaged. Blizzlike is false
+constexpr bool WEB_GRAB_OVERRIDE                        = true;  // Emulate web grab by using range-locked single target spell looping through and grabbing valid targets in range. Sniffed spell has too long range and grabs through floor. Blizzlike is false but bugged
+
 enum Spells
 {
     SPELL_SUMMON_ANUBAR_CHAMPION            = 53064,
@@ -34,7 +39,8 @@ enum Spells
     SPELL_ACID_CLOUD                        = 53400,
     SPELL_LEECH_POISON                      = 53030,
     SPELL_LEECH_POISON_HEAL                 = 53800,
-    SPELL_WEB_GRAB                          = 56640,
+    SPELL_WEB_GRAB                          = 57731,
+    SPELL_WEB_GRAB_OVERRIDE                 = 56640,
     SPELL_PIERCE_ARMOR                      = 53418,
 
     SPELL_SMASH                             = 53318,
@@ -60,10 +66,9 @@ enum Events
     EVENT_HADRONOX_PIERCE           = 7,
     EVENT_HADRONOX_GRAB             = 8,
     EVENT_HADRONOX_CHECK            = 10,
-    EVENT_HADRONOX_SUMMON_CHAMPION  = 11,
-    EVENT_HADRONOX_SUMMON_NECRO     = 12,
-    EVENT_HADRONOX_SUMMON_CRYPT     = 13,
+    EVENT_HADRONOX_SUMMON_ADD       = 11,
     EVENT_HADRONOX_STEP             = 14,
+    EVENT_HADRONOX_NEXT_WAYPOINT    = 15,
 
     EVENT_CRUSHER_SMASH             = 20,
     EVENT_CHECK_HEALTH              = 21,
@@ -88,18 +93,21 @@ enum Misc
     ACTION_START_EVENT          = 2,
     ACTION_START_WALK           = 3,
     ACTION_STOP_SPAWNS          = 4,
-    ACTION_CRUSHER_EVADE        = 5
+    ACTION_CRUSHER_EVADE        = 5,
+    ACTION_CRUSHER_AGGRO_SAY    = 6
 };
 
-constexpr float GAUNTLET_END_Z   = 640.0f;
-constexpr float GAUNTLET_START_Z = 730.0f;
-constexpr float STEP_REACH       = 3.0f;
-constexpr float STEP_SPEED       = 3.5f;
-constexpr float ADDS_RANGE       = 8.0f;
-constexpr float SPELL_MAX_DIST   = 40.0f;
-constexpr float SPELL_MAX_Z_DIFF = 20.0f;
-constexpr float WAYPOINT_REACH   = 1.0f;
-constexpr uint32 ADD_CHECK_MS    = 100;
+constexpr float GAUNTLET_END_Z        = 640.0f;
+constexpr float GAUNTLET_START_Z      = 730.0f;
+constexpr float STEP_REACH            = 3.0f;
+constexpr float STEP_SPEED            = 4.5f;
+constexpr float ADDS_RANGE            = 8.0f;
+constexpr float SPELL_MAX_DIST        = 40.0f;
+constexpr float SPELL_MAX_Z_DIFF      = 20.0f;
+constexpr float WAYPOINT_REACH        = 1.0f;
+constexpr uint32 ADD_CHECK_MS         = 100;
+constexpr float HADRONOX_LEASH_RANGE  = 10.0f;
+constexpr uint32 HADRONOX_LEASH_CHECK = 2000;
 const Position HADRONOX_SPAWN_POS = {522.531f, 544.911f, 674.679f, 0.0f};
 
 const Position hadronoxWaypoints[8] =
@@ -114,10 +122,11 @@ const Position hadronoxWaypoints[8] =
     {534.87f,    554.0f,     733.0f,     0.0f}
 };
 
-const Position addSpawnPos[2] =
+const Position addSpawnPos[3] =
 {
     {577.2f, 613.45f, 771.51f, 0.0f},
-    {483.68f, 612.75f, 771.42f, 0.0f}
+    {483.68f, 612.75f, 771.42f, 0.0f},
+    {584.7559f, 603.21466f, 739.14014f, 0.0f}
 };
 
 constexpr uint32 ADD_WAYPOINT_COUNT = 15;
@@ -140,6 +149,8 @@ const Position addWaypoints[ADD_WAYPOINT_COUNT] =
     {540.6518f,  532.722f,   684.9354f,  0.0f}
 };
 
+const Position ADD_SPAWN3_JOIN_WP = {609.41376f, 574.623f, 722.0532f, 0.0f};
+
 static bool IsValidSpellTarget(Unit* caster, WorldObject* target)
 {
     if (!caster || !target)
@@ -158,17 +169,21 @@ struct npc_hadronox_addAI : public ScriptedAI
         _currentWaypoint = 0;
         _reachedHadronox = false;
         _attackedByPlayer = false;
-        _spawnedAbove745 = creature->GetPositionZ() >= 745.0f;
+        _spawnedAbove735 = creature->GetPositionZ() >= 735.0f;
         _chasingHadronox = false;
         _checkTimer = 0;
+        _spawnIndex = -1;
+        _joinedMainPath = false;
     }
 
     uint32 _currentWaypoint;
     bool _reachedHadronox;
     bool _attackedByPlayer;
-    bool _spawnedAbove745;
+    bool _spawnedAbove735;
     bool _chasingHadronox;
     uint32 _checkTimer;
+    int32 _spawnIndex;
+    bool _joinedMainPath;
     EventMap events;
 
     bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
@@ -180,9 +195,17 @@ struct npc_hadronox_addAI : public ScriptedAI
         _attackedByPlayer = false;
         _chasingHadronox = false;
         _checkTimer = 0;
+        _joinedMainPath = false;
         events.Reset();
-        if (_spawnedAbove745)
+        if (_spawnedAbove735)
             IssueMove();
+    }
+
+    void SetData(uint32 /*id*/, uint32 value) override
+    {
+        _spawnIndex = (int32)value;
+        _spawnedAbove735 = true;
+        IssueMove();
     }
 
     Creature* FindHadronox() const
@@ -207,6 +230,22 @@ struct npc_hadronox_addAI : public ScriptedAI
     // Issues MovePoint to current waypoint, or MovePoint to Hadronox if closer.
     void IssueMove()
     {
+        if (_spawnIndex == 2 && !_joinedMainPath)
+        {
+            Creature* hadronox = FindHadronox();
+            if (hadronox && me->GetExactDist(hadronox) <= ADDS_RANGE)
+            {
+                EngageHadronox(hadronox);
+                return;
+            }
+            me->GetMotionMaster()->MovePoint(9999,
+                ADD_SPAWN3_JOIN_WP.GetPositionX(),
+                ADD_SPAWN3_JOIN_WP.GetPositionY(),
+                ADD_SPAWN3_JOIN_WP.GetPositionZ(),
+                FORCED_MOVEMENT_RUN);
+            return;
+        }
+
         Creature* hadronox = FindHadronox();
 
         if (hadronox)
@@ -269,7 +308,7 @@ struct npc_hadronox_addAI : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (!_spawnedAbove745 || _reachedHadronox || _attackedByPlayer)
+        if (!_spawnedAbove735 || _reachedHadronox || _attackedByPlayer)
             return;
 
         Creature* hadronox = FindHadronox();
@@ -277,6 +316,19 @@ struct npc_hadronox_addAI : public ScriptedAI
         if (hadronox && me->GetExactDist(hadronox) <= ADDS_RANGE)
         {
             EngageHadronox(hadronox);
+            return;
+        }
+
+        if (_spawnIndex == 2 && !_joinedMainPath)
+        {
+            if (me->GetExactDist(ADD_SPAWN3_JOIN_WP) <= WAYPOINT_REACH)
+            {
+                _joinedMainPath = true;
+                _currentWaypoint = 8;
+                IssueMove();
+            }
+            else if (!me->isMoving())
+                IssueMove();
             return;
         }
 
@@ -359,7 +411,7 @@ public:
         {
             npc_hadronox_addAI::UpdateAI(diff);
 
-            if (_spawnedAbove745 && !ShouldUseCombatAbilities())
+            if (_spawnedAbove735 && !ShouldUseCombatAbilities())
                 me->SetReactState(REACT_PASSIVE);
             else if (me->GetReactState() == REACT_PASSIVE)
             {
@@ -427,7 +479,7 @@ public:
         {
             npc_hadronox_addAI::UpdateAI(diff);
 
-            if (_spawnedAbove745 && !ShouldUseCombatAbilities())
+            if (_spawnedAbove735 && !ShouldUseCombatAbilities())
                 me->SetReactState(REACT_PASSIVE);
             else if (me->GetReactState() == REACT_PASSIVE)
             {
@@ -495,7 +547,7 @@ public:
         {
             npc_hadronox_addAI::UpdateAI(diff);
 
-            if (_spawnedAbove745 && !ShouldUseCombatAbilities())
+            if (_spawnedAbove735 && !ShouldUseCombatAbilities())
                 me->SetReactState(REACT_PASSIVE);
             else if (me->GetReactState() == REACT_PASSIVE)
             {
@@ -552,6 +604,10 @@ public:
             _spawnCount = 0;
             _movementCheckTimer = 0;
             _lastPos = creature->GetPosition();
+            _waitingForNextStep = false;
+            _reachedFinalWaypoint = false;
+            _leashPos = {0.0f, 0.0f, 0.0f, 0.0f};
+            _leashCheckTimer = 0;
         }
 
         bool _walkStarted;
@@ -559,10 +615,14 @@ public:
         bool _combatStarted;
         bool _playerAttacked;
         bool _crusherAggroSaid;
+        bool _waitingForNextStep;
+        bool _reachedFinalWaypoint;
         int32 _currentStep;
         uint32 _spawnCount;
         uint32 _movementCheckTimer;
+        uint32 _leashCheckTimer;
         Position _lastPos;
+        Position _leashPos;
 
         void Reset() override
         {
@@ -575,6 +635,10 @@ public:
             _currentStep = -1;
             _spawnCount = 0;
             _movementCheckTimer = 0;
+            _waitingForNextStep = false;
+            _reachedFinalWaypoint = false;
+            _leashPos = {0.0f, 0.0f, 0.0f, 0.0f};
+            _leashCheckTimer = 0;
             _lastPos = me->GetPosition();
             me->SummonCreature(NPC_ANUB_AR_CRUSHER, 531.5281f, 553.8509f, 732.56f, 5.053f);
             me->SummonCreature(NPC_ANUB_AR_CRYPTFIEND, 524.07886f, 550.6797f, 731.873f, 5.053f);
@@ -588,6 +652,12 @@ public:
                 return;
             if (index == 6)
                 me->CastSpell(me, SPELL_WEB_FRONT_DOORS, true);
+            if (index == 7)
+            {
+                me->CastSpell(me, SPELL_WEB_SIDE_DOORS, true);
+                _spawnsActive = false;
+                events.CancelEvent(EVENT_HADRONOX_SUMMON_ADD);
+            }
             me->GetMotionMaster()->MoveCharge(
                 hadronoxWaypoints[index].GetPositionX(),
                 hadronoxWaypoints[index].GetPositionY(),
@@ -608,22 +678,23 @@ public:
 
         void StartSummonEvents()
         {
-            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CHAMPION, 15s);
-            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_NECRO, 10s);
-            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CRYPT, 5s);
+            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_ADD, 2s);
         }
 
         Position GetNextSpawnPos()
         {
-            return addSpawnPos[_spawnCount % 2];
+            return addSpawnPos[_spawnCount % 3];
         }
 
         void SummonAdd(uint32 entry)
         {
             if (!_spawnsActive)
                 return;
-            Position pos = GetNextSpawnPos();
-            me->SummonCreature(entry, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
+            uint32 spawnIndex = _spawnCount % 3;
+            Position pos = addSpawnPos[spawnIndex];
+            Creature* add = me->SummonCreature(entry, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
+            if (add)
+                add->AI()->SetData(0, spawnIndex);
             _spawnCount++;
         }
 
@@ -635,6 +706,16 @@ public:
                 _spawnsActive = false;
             else if (param == ACTION_CRUSHER_EVADE)
                 me->AI()->EnterEvadeMode();
+            else if (param == ACTION_CRUSHER_AGGRO_SAY)
+            {
+                if (!_crusherAggroSaid)
+                {
+                    _crusherAggroSaid = true;
+                    if (Creature* crusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 300.0f, true))
+                        crusher->AI()->Talk(SAY_CRUSHER_AGGRO);
+                    StartSummonEvents();
+                }
+            }
         }
 
         void EnterEvadeMode(EvadeReason /*why*/) override
@@ -683,31 +764,35 @@ public:
             if (who && who->IsControlledByPlayer() && !_playerAttacked)
             {
                 _playerAttacked = true;
-                _spawnsActive = false;
-                events.CancelEvent(EVENT_HADRONOX_STEP);
-                me->GetMotionMaster()->Clear();
 
-                std::list<Creature*> cl;
-                me->GetCreaturesWithEntryInRange(cl, 30.0f, 28922);
-                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
-                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+                if (PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS)
+                {
+                    _spawnsActive = false;
+                    events.CancelEvent(EVENT_HADRONOX_SUMMON_ADD);
+                    me->GetMotionMaster()->Clear();
 
-                cl.clear();
-                me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_CHAMPION);
-                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
-                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+                    std::list<Creature*> cl;
+                    me->GetCreaturesWithEntryInRange(cl, 30.0f, 28922);
+                    for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                        (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
 
-                cl.clear();
-                me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_NECROMANCER);
-                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
-                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+                    cl.clear();
+                    me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_CHAMPION);
+                    for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                        (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
 
-                cl.clear();
-                me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_CRYPTFIEND);
-                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
-                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+                    cl.clear();
+                    me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_NECROMANCER);
+                    for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                        (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
 
-                me->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+                    cl.clear();
+                    me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_CRYPTFIEND);
+                    for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                        (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+
+                    me->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+                }
             }
 
             if ((!who || !who->IsControlledByPlayer()) && me->HealthBelowPct(70))
@@ -761,35 +846,49 @@ public:
 
         void CastWebGrabOnValidTargets()
         {
-            std::list<Unit*> targets;
-
-            Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
-            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+            if (WEB_GRAB_OVERRIDE)
             {
-                Player* player = itr->GetSource();
-                if (!player || !player->IsAlive() || player->IsGameMaster())
-                    continue;
-                if (!IsValidSpellTarget(me, player))
-                    continue;
-                targets.push_back(player);
-            }
+                std::list<Unit*> targets;
 
-            for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
-            {
-                std::list<Creature*> cl;
-                me->GetCreaturesWithEntryInRange(cl, SPELL_MAX_DIST, entry);
-                for (Creature* c : cl)
+                Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+                for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
                 {
-                    if (!c->IsAlive())
+                    Player* player = itr->GetSource();
+                    if (!player || !player->IsAlive() || player->IsGameMaster())
                         continue;
-                    if (!IsValidSpellTarget(me, c))
+                    if (!IsValidSpellTarget(me, player))
                         continue;
-                    targets.push_back(c);
+                    targets.push_back(player);
                 }
-            }
 
-            for (Unit* target : targets)
-                me->CastSpell(target, SPELL_WEB_GRAB, false);
+                for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
+                {
+                    std::list<Creature*> cl;
+                    me->GetCreaturesWithEntryInRange(cl, SPELL_MAX_DIST, entry);
+                    for (Creature* c : cl)
+                    {
+                        if (!c->IsAlive())
+                            continue;
+                        if (!IsValidSpellTarget(me, c))
+                            continue;
+                        targets.push_back(c);
+                    }
+                }
+
+                for (Unit* target : targets)
+                    me->CastSpell(target, SPELL_WEB_GRAB_OVERRIDE, false);
+            }
+            else
+            {
+                me->CastSpell(me, SPELL_WEB_GRAB, false);
+            }
+        }
+
+        float GetDistXY(const Position& a, const Position& b) const
+        {
+            float dx = a.GetPositionX() - b.GetPositionX();
+            float dy = a.GetPositionY() - b.GetPositionY();
+            return std::sqrt(dx * dx + dy * dy);
         }
 
         void UpdateAI(uint32 diff) override
@@ -806,17 +905,27 @@ public:
                     const Position& dest = hadronoxWaypoints[_currentStep];
                     float distToDest = me->GetExactDist(dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ());
 
-                    if (distToDest <= STEP_REACH)
+                    if (!_waitingForNextStep && distToDest <= STEP_REACH)
                     {
                         _currentStep++;
                         if (_currentStep < 8)
                         {
                             if (_currentStep >= 4)
+                            {
                                 Talk(SAY_HADRONOX_EMOTE);
-                            MoveToWaypoint(_currentStep);
+                                _waitingForNextStep = true;
+                                events.ScheduleEvent(EVENT_HADRONOX_NEXT_WAYPOINT, 15s);
+                            }
+                            else
+                                MoveToWaypoint(_currentStep);
+                        }
+                        else
+                        {
+                            _reachedFinalWaypoint = true;
+                            _leashPos = me->GetPosition();
                         }
                     }
-                    else
+                    else if (!_waitingForNextStep)
                     {
                         float movedDist = me->GetExactDist(_lastPos.GetPositionX(), _lastPos.GetPositionY(), _lastPos.GetPositionZ());
                         if (movedDist < 0.1f)
@@ -832,6 +941,23 @@ public:
                 }
             }
 
+            if (_reachedFinalWaypoint && !_playerAttacked && me->IsInCombat())
+            {
+                _leashCheckTimer += diff;
+                if (_leashCheckTimer >= HADRONOX_LEASH_CHECK)
+                {
+                    _leashCheckTimer = 0;
+                    if (GetDistXY(me->GetPosition(), _leashPos) > HADRONOX_LEASH_RANGE)
+                    {
+                        me->GetMotionMaster()->MovePoint(0,
+                            _leashPos.GetPositionX(),
+                            _leashPos.GetPositionY(),
+                            _leashPos.GetPositionZ(),
+                            FORCED_MOVEMENT_RUN);
+                    }
+                }
+            }
+
             switch (uint32 eventId = events.ExecuteEvent())
             {
                 case EVENT_HADRONOX_CHECK:
@@ -839,7 +965,7 @@ public:
                     {
                         if (AnyPlayerInHadronoxGauntlet())
                         {
-                            if (!_crusherAggroSaid)
+                            if (!_crusherAggroSaid && CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
                             {
                                 _crusherAggroSaid = true;
                                 if (Creature* crusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 300.0f, true))
@@ -858,18 +984,20 @@ public:
                     _currentStep = 0;
                     MoveToWaypoint(0);
                     break;
-                case EVENT_HADRONOX_SUMMON_CHAMPION:
-                    SummonAdd(NPC_ANUB_AR_CHAMPION);
-                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CHAMPION, 15s);
+                case EVENT_HADRONOX_NEXT_WAYPOINT:
+                    _waitingForNextStep = false;
+                    if (_currentStep < 8)
+                        MoveToWaypoint(_currentStep);
                     break;
-                case EVENT_HADRONOX_SUMMON_NECRO:
-                    SummonAdd(NPC_ANUB_AR_NECROMANCER);
-                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_NECRO, 10s);
+                case EVENT_HADRONOX_SUMMON_ADD:
+                {
+                    // Using weight from original Hadronox script (2 champions, 3 necromancers, 6 cryptfiends per 30 sec)
+                    uint32 roll = urand(0, 11);
+                    uint32 entry = (roll < 2) ? NPC_ANUB_AR_CHAMPION : (roll < 5) ? NPC_ANUB_AR_NECROMANCER : NPC_ANUB_AR_CRYPTFIEND;
+                    SummonAdd(entry);
+                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_ADD, 2s);
                     break;
-                case EVENT_HADRONOX_SUMMON_CRYPT:
-                    SummonAdd(NPC_ANUB_AR_CRYPTFIEND);
-                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CRYPT, 5s);
-                    break;
+                }
                 case EVENT_HADRONOX_PIERCE:
                     if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
                         if (me->GetVictim() && IsValidSpellTarget(me, me->GetVictim()))
@@ -892,7 +1020,7 @@ public:
                 case EVENT_HADRONOX_GRAB:
                     if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
                         CastWebGrabOnValidTargets();
-                    events.ScheduleEvent(EVENT_HADRONOX_GRAB, 12s);
+                    events.ScheduleEvent(EVENT_HADRONOX_GRAB, 25s);
                     break;
             }
 
@@ -924,23 +1052,96 @@ public:
         npc_anub_ar_crusherAI(Creature* c) : ScriptedAI(c), summons(me)
         {
             _eventStarted = false;
+            _isSpawnedCrusher = false;
+            _pathStep = 0;
+            _pathCheckTimer = 0;
+            _finalDest = {0.0f, 0.0f, 0.0f, 0.0f};
         }
 
         EventMap events;
         SummonList summons;
         bool _eventStarted;
+        bool _isSpawnedCrusher;
+        uint32 _pathStep;
+        uint32 _pathCheckTimer;
+        Position _finalDest;
 
         void Reset() override
         {
             summons.DespawnAll();
             events.Reset();
             _eventStarted = false;
+            if (!_isSpawnedCrusher)
+                _pathStep = 0;
+        }
+
+        void SetData(uint32 /*id*/, uint32 /*value*/) override
+        {
+            _isSpawnedCrusher = true;
+        }
+
+        void SetDestination(const Position& dest)
+        {
+            _finalDest = dest;
+            _pathStep = 1;
+            me->GetMotionMaster()->MovePoint(1,
+                addWaypoints[0].GetPositionX(),
+                addWaypoints[0].GetPositionY(),
+                addWaypoints[0].GetPositionZ(),
+                FORCED_MOVEMENT_RUN);
         }
 
         void JustEngagedWith(Unit*) override
         {
-            if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
-                hadronox->AI()->DoAction(ACTION_START_WALK);
+            if (!_isSpawnedCrusher)
+            {
+                if (!CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
+                {
+                    if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+                        hadronox->AI()->DoAction(ACTION_CRUSHER_AGGRO_SAY);
+                }
+
+                if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+                    hadronox->AI()->DoAction(ACTION_START_WALK);
+
+                const Position dest1 = {521.5181f,  563.6016f, 733.81036f, 0.0f};
+                const Position dest2 = {539.27893f, 564.9075f, 731.92096f, 0.0f};
+
+                Creature* c1 = me->SummonCreature(NPC_ANUB_AR_CRUSHER,
+                    addSpawnPos[0].GetPositionX(), addSpawnPos[0].GetPositionY(), addSpawnPos[0].GetPositionZ(), 0.0f,
+                    TEMPSUMMON_CORPSE_TIMED_DESPAWN, 10000);
+                Creature* c2 = me->SummonCreature(NPC_ANUB_AR_CRUSHER,
+                    addSpawnPos[1].GetPositionX(), addSpawnPos[1].GetPositionY(), addSpawnPos[1].GetPositionZ(), 0.0f,
+                    TEMPSUMMON_CORPSE_TIMED_DESPAWN, 10000);
+
+                if (c1 && c2)
+                {
+                    float c1DistToDest1 = c1->GetExactDist(dest1);
+                    float c1DistToDest2 = c1->GetExactDist(dest2);
+
+                    const Position& assignDest1 = (c1DistToDest1 <= c1DistToDest2) ? dest1 : dest2;
+                    const Position& assignDest2 = (c1DistToDest1 <= c1DistToDest2) ? dest2 : dest1;
+
+                    c1->AI()->SetData(0, 0);
+                    static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(assignDest1);
+
+                    c2->AI()->SetData(0, 0);
+                    static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(assignDest2);
+                }
+                else
+                {
+                    if (c1)
+                    {
+                        c1->AI()->SetData(0, 0);
+                        static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(dest1);
+                    }
+                    if (c2)
+                    {
+                        c2->AI()->SetData(0, 0);
+                        static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(dest2);
+                    }
+                }
+            }
 
             events.ScheduleEvent(EVENT_CRUSHER_SMASH, 8s, 0, 0);
             events.ScheduleEvent(EVENT_CHECK_HEALTH, 1s);
@@ -948,14 +1149,60 @@ public:
 
         void EnterEvadeMode(EvadeReason /*why*/) override
         {
-            if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
-                hadronox->AI()->DoAction(ACTION_CRUSHER_EVADE);
+            if (!_isSpawnedCrusher)
+            {
+                if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+                    hadronox->AI()->DoAction(ACTION_CRUSHER_EVADE);
+            }
 
             ScriptedAI::EnterEvadeMode();
         }
 
         void UpdateAI(uint32 diff) override
         {
+            if (_isSpawnedCrusher && _pathStep > 0)
+            {
+                _pathCheckTimer += diff;
+                if (_pathCheckTimer >= 200)
+                {
+                    _pathCheckTimer = 0;
+
+                    if (_pathStep == 1)
+                    {
+                        if (me->GetExactDist(addWaypoints[0]) <= WAYPOINT_REACH)
+                        {
+                            _pathStep = 2;
+                            me->GetMotionMaster()->MovePoint(2,
+                                _finalDest.GetPositionX(),
+                                _finalDest.GetPositionY(),
+                                _finalDest.GetPositionZ(),
+                                FORCED_MOVEMENT_RUN);
+                        }
+                        else if (!me->isMoving())
+                        {
+                            me->GetMotionMaster()->MovePoint(1,
+                                addWaypoints[0].GetPositionX(),
+                                addWaypoints[0].GetPositionY(),
+                                addWaypoints[0].GetPositionZ(),
+                                FORCED_MOVEMENT_RUN);
+                        }
+                    }
+                    else if (_pathStep == 2)
+                    {
+                        if (me->GetExactDist(_finalDest) <= WAYPOINT_REACH)
+                            _pathStep = 0;
+                        else if (!me->isMoving())
+                        {
+                            me->GetMotionMaster()->MovePoint(2,
+                                _finalDest.GetPositionX(),
+                                _finalDest.GetPositionY(),
+                                _finalDest.GetPositionZ(),
+                                FORCED_MOVEMENT_RUN);
+                        }
+                    }
+                }
+            }
+
             if (!UpdateVictim())
                 return;
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1068,19 +1068,12 @@ public:
 
             if (_reachedFinalWaypoint && me->IsInCombat())
             {
-                bool fightingNpc = false;
-                for (auto* ref : me->GetThreatMgr().GetThreatList())
-                {
-                    Unit* victim = ref->GetVictim();
-                    if (!victim)
-                        continue;
-                    uint32 entry = victim->GetEntry();
-                    if (entry == NPC_ANUB_AR_CRUSHER || entry == NPC_ANUB_AR_CHAMPION || entry == NPC_ANUB_AR_NECROMANCER || entry == NPC_ANUB_AR_CRYPTFIEND)
-                    {
-                        fightingNpc = true;
-                        break;
-                    }
-                }
+                Unit* topThreat = me->GetThreatMgr().GetCurrentVictim();
+                bool fightingNpc = topThreat && !topThreat->IsControlledByPlayer() && (
+                    topThreat->GetEntry() == NPC_ANUB_AR_CRUSHER ||
+                    topThreat->GetEntry() == NPC_ANUB_AR_CHAMPION ||
+                    topThreat->GetEntry() == NPC_ANUB_AR_NECROMANCER ||
+                    topThreat->GetEntry() == NPC_ANUB_AR_CRYPTFIEND);
 
                 if (fightingNpc)
                 {
@@ -1098,7 +1091,7 @@ public:
                         }
                     }
                 }
-                else
+                else if (me->GetThreatMgr().GetThreatList().empty())
                     me->GetMotionMaster()->Clear();
             }
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -847,7 +847,32 @@ public:
             if (index < 0 || index >= 8)
                 return;
             if (index == 6)
+            {
                 SpawnWebDummy(0);
+
+                std::list<Creature*> crushers;
+                me->GetCreaturesWithEntryInRange(crushers, 500.0f, NPC_ANUB_AR_CRUSHER);
+
+                Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+                for (Creature* crusher : crushers)
+                {
+                    if (!crusher->IsAlive() || crusher->IsInCombat())
+                        continue;
+                    for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+                    {
+                        Player* player = itr->GetSource();
+                        if (!player || !player->IsAlive() || player->IsGameMaster())
+                            continue;
+                        float z = player->GetPositionZ();
+                        float y = player->GetPositionY();
+                        if (y < GAUNTLET_MAX_Y && z > GAUNTLET_END_Z)
+                        {
+                            crusher->AI()->AttackStart(player);
+                            crusher->AddThreat(player, 1.0f);
+                        }
+                    }
+                }
+            }
             if (index == 7)
             {
                 SpawnWebDummy(1);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -27,7 +27,6 @@
 // Configs
 constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = false; // Blizzlike is false, true is more akin to other pservers
 constexpr bool HADRONOX_STOP_ASCENT_ON_PLAYER_DAMAGE    = true;  // Blizzlike is true
-constexpr bool CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER      = false; // true = on player entering gauntlet (y < 625), false = on crusher engaged. Blizzlike is false
 constexpr bool WEB_GRAB_OVERRIDE                        = true;  // Emulate web grab by using range-locked single target spell looping through and grabbing valid targets in range. Sniffed spell has too long range and grabs through floor. Blizzlike is false but bugged
 
 enum Spells
@@ -36,7 +35,7 @@ enum Spells
     SPELL_SUMMON_ANUBAR_CRYPT_FIEND         = 53065,
     SPELL_SUMMON_ANUBAR_NECROMANCER         = 53066,
     SPELL_WEB_FRONT_DOORS                   = 53177, // Unscripted
-    SPELL_WEB_SIDE_DOORS                    = 53185,
+    SPELL_WEB_SIDE_DOORS                    = 53185, // Apply flat aura on dummy instead of using spell cast
     SPELL_ACID_CLOUD                        = 53400,
     SPELL_LEECH_POISON                      = 53030,
     SPELL_LEECH_POISON_HEAL                 = 53800,
@@ -686,6 +685,7 @@ public:
             _combatStarted = false;
             _playerAttacked = false;
             _crusherAggroSaid = false;
+            _startedSummons = false;
             _currentStep = -1;
             _spawnCount = 0;
             _movementCheckTimer = 0;
@@ -701,6 +701,7 @@ public:
         bool _combatStarted;
         bool _playerAttacked;
         bool _crusherAggroSaid;
+        bool _startedSummons;
         bool _waitingForNextStep;
         bool _reachedFinalWaypoint;
         int32 _currentStep;
@@ -719,6 +720,7 @@ public:
             _combatStarted = false;
             _playerAttacked = false;
             _crusherAggroSaid = false;
+            _startedSummons = false;
             _currentStep = -1;
             _spawnCount = 0;
             _movementCheckTimer = 0;
@@ -924,6 +926,21 @@ public:
             }
             return false;
         }
+        
+        bool AnyPlayerInHadronoxUpperGauntlet() const
+        {
+            Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+            {
+                Player* player = itr->GetSource();
+                if (!player || player->IsGameMaster())
+                    continue;
+                float z = player->GetPositionZ();
+                if (player->IsAlive() && z > GAUNTLET_END_Z && z < 785.0f)
+                    return true;
+            }
+            return false;
+        }
 
         bool AnyPlayerInHadronoxGauntlet() const
         {
@@ -1112,16 +1129,17 @@ public:
                 case EVENT_HADRONOX_CHECK:
                     if (me->IsAlive() && instance->IsBossDone(DATA_KRIKTHIR))
                     {
-                        if (AnyPlayerInHadronoxGauntlet())
+                        if (AnyPlayerInHadronoxUpperGauntlet())
                         {
-                            if (!_crusherAggroSaid)
+                            if (!_startedSummons)
                             {
-                                _crusherAggroSaid = true;
-                                if (CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
-                                    if (Creature* crusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 300.0f, true))
-                                        crusher->AI()->Talk(SAY_CRUSHER_AGGRO);
+                                _startedSummons = true;
                                 StartSummonEvents();
                             }
+                        }
+                        
+                        if (AnyPlayerInHadronoxGauntlet())
+                        {
                             if (!_walkStarted && AnyPlayerBelowWalkTrigger())
                                 StartWalkEvent();
                         }
@@ -1294,11 +1312,8 @@ public:
             }
             else
             {
-                if (!CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
-                {
-                    if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
-                        hadronox->AI()->DoAction(ACTION_CRUSHER_AGGRO_SAY);
-                }
+                if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+                    hadronox->AI()->DoAction(ACTION_CRUSHER_AGGRO_SAY);
 
                 if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
                     hadronox->AI()->DoAction(ACTION_START_WALK);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -693,8 +693,6 @@ public:
             _reachedFinalWaypoint = false;
             _leashPos = {0.0f, 0.0f, 0.0f, 0.0f};
             _leashCheckTimer = 0;
-            _webDoorPhase = 0;
-            _dummiesSpawned = false;
         }
 
         bool _walkStarted;
@@ -704,15 +702,12 @@ public:
         bool _crusherAggroSaid;
         bool _waitingForNextStep;
         bool _reachedFinalWaypoint;
-        bool _dummiesSpawned;
         int32 _currentStep;
         uint32 _spawnCount;
         uint32 _movementCheckTimer;
         uint32 _leashCheckTimer;
-        uint32 _webDoorPhase;
         Position _lastPos;
         Position _leashPos;
-        ObjectGuid _webDummyGuids[3];
 
         void Reset() override
         {
@@ -730,10 +725,6 @@ public:
             _reachedFinalWaypoint = false;
             _leashPos = {0.0f, 0.0f, 0.0f, 0.0f};
             _leashCheckTimer = 0;
-            _webDoorPhase = 0;
-            _dummiesSpawned = false;
-            for (int i = 0; i < 3; ++i)
-                _webDummyGuids[i].Clear();
             _lastPos = me->GetPosition();
             me->SummonCreature(NPC_ANUB_AR_CRUSHER, 531.5281f, 553.8509f, 732.56f, 5.053f);
             me->SummonCreature(NPC_ANUB_AR_CRYPTFIEND, 524.07886f, 550.6797f, 731.873f, 5.053f);
@@ -741,24 +732,20 @@ public:
             events.ScheduleEvent(EVENT_HADRONOX_CHECK, 1s);
         }
 
-        void SpawnWebDummies()
+        void SpawnWebDummy(uint32 index)
         {
-            if (_dummiesSpawned)
+            if (index >= 3)
                 return;
-            _dummiesSpawned = true;
-            for (int i = 0; i < 3; ++i)
+            if (Creature* dummy = me->SummonCreature(NPC_WEB_DUMMY_TARGET,
+                webDummyPositions[index].GetPositionX(),
+                webDummyPositions[index].GetPositionY(),
+                webDummyPositions[index].GetPositionZ(),
+                webDummyPositions[index].GetOrientation(),
+                TEMPSUMMON_MANUAL_DESPAWN))
             {
-                if (Creature* dummy = me->SummonCreature(NPC_WEB_DUMMY_TARGET,
-                    webDummyPositions[i].GetPositionX(),
-                    webDummyPositions[i].GetPositionY(),
-                    webDummyPositions[i].GetPositionZ(),
-                    webDummyPositions[i].GetOrientation(),
-                    TEMPSUMMON_MANUAL_DESPAWN))
-                {
-                    _webDummyGuids[i] = dummy->GetGUID();
-                    dummy->SetReactState(REACT_PASSIVE);
-                    dummy->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
-                }
+                dummy->SetReactState(REACT_PASSIVE);
+                dummy->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+                dummy->AddAura(SPELL_WEB_SIDE_DOORS, dummy);
             }
         }
 
@@ -767,14 +754,11 @@ public:
             if (index < 0 || index >= 8)
                 return;
             if (index == 6)
-            {
-                _webDoorPhase = 1;
-                me->CastSpell(me, SPELL_WEB_SIDE_DOORS, true);
-            }
+                SpawnWebDummy(0);
             if (index == 7)
             {
-                _webDoorPhase = 2;
-                me->CastSpell(me, SPELL_WEB_SIDE_DOORS, true);
+                SpawnWebDummy(1);
+                SpawnWebDummy(2);
                 _spawnsActive = false;
                 events.CancelEvent(EVENT_HADRONOX_SUMMON_ADD);
             }
@@ -793,7 +777,6 @@ public:
             _walkStarted = true;
             instance->SetBossState(DATA_HADRONOX, IN_PROGRESS);
             me->setActive(true);
-            SpawnWebDummies();
             events.ScheduleEvent(EVENT_HADRONOX_STEP, 10s);
         }
 
@@ -850,16 +833,7 @@ public:
         {
             if (data == me->GetEntry())
                 return (_currentStep < 7) ? 1 : 0;
-            if (data == 0xDEAD1)
-                return _webDoorPhase;
             return 0;
-        }
-
-        ObjectGuid GetWebDummyGuid(uint32 index) const
-        {
-            if (index < 3)
-                return _webDummyGuids[index];
-            return ObjectGuid::Empty;
         }
 
         void JustSummoned(Creature* summon) override
@@ -1494,61 +1468,6 @@ class spell_hadronox_leech_poison_aura : public AuraScript
     }
 };
 
-class spell_hadronox_web_side_doors : public SpellScript
-{
-    PrepareSpellScript(spell_hadronox_web_side_doors);
-
-    void FilterTargets(std::list<WorldObject*>& targets)
-    {
-        Unit* caster = GetCaster();
-        if (!caster)
-        {
-            targets.clear();
-            return;
-        }
-
-        Creature* hadronox = caster->ToCreature();
-        if (!hadronox)
-        {
-            targets.clear();
-            return;
-        }
-
-        uint32 phase = hadronox->AI()->GetData(0xDEAD1);
-
-        targets.remove_if([hadronox, phase](WorldObject* obj) -> bool
-        {
-            Creature* creature = obj->ToCreature();
-            if (!creature || creature->GetEntry() != NPC_WEB_DUMMY_TARGET)
-                return true;
-
-            ObjectGuid guid = creature->GetGUID();
-
-            if (phase == 1)
-            {
-                boss_hadronox::boss_hadronoxAI* ai = dynamic_cast<boss_hadronox::boss_hadronoxAI*>(hadronox->AI());
-                if (!ai)
-                    return true;
-                return guid != ai->GetWebDummyGuid(0);
-            }
-            else if (phase == 2)
-            {
-                boss_hadronox::boss_hadronoxAI* ai = dynamic_cast<boss_hadronox::boss_hadronoxAI*>(hadronox->AI());
-                if (!ai)
-                    return true;
-                return guid != ai->GetWebDummyGuid(1) && guid != ai->GetWebDummyGuid(2);
-            }
-
-            return true;
-        });
-    }
-
-    void Register() override
-    {
-        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hadronox_web_side_doors::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENTRY);
-    }
-};
-
 class achievement_hadronox_denied : public AchievementCriteriaScript
 {
 public:
@@ -1573,6 +1492,5 @@ void AddSC_boss_hadronox()
     new boss_hadronox();
     new npc_anub_ar_crusher();
     RegisterSpellScript(spell_hadronox_leech_poison_aura);
-    RegisterSpellScript(spell_hadronox_web_side_doors);
     new achievement_hadronox_denied();
 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -821,6 +821,7 @@ public:
         {
             if (AnyPlayerInHadronoxGauntlet())
                 return;
+            me->RemoveAllDynObjects();
             BossAI::EnterEvadeMode();
         }
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -34,7 +34,7 @@ enum Spells
     SPELL_SUMMON_ANUBAR_CHAMPION            = 53064,
     SPELL_SUMMON_ANUBAR_CRYPT_FIEND         = 53065,
     SPELL_SUMMON_ANUBAR_NECROMANCER         = 53066,
-    SPELL_WEB_FRONT_DOORS                   = 53177,
+    SPELL_WEB_FRONT_DOORS                   = 53177, // Unscripted
     SPELL_WEB_SIDE_DOORS                    = 53185,
     SPELL_ACID_CLOUD                        = 53400,
     SPELL_LEECH_POISON                      = 53030,
@@ -87,6 +87,7 @@ enum Events
 enum Misc
 {
     NPC_ANUB_AR_CRUSHER         = 28922,
+    NPC_WEB_DUMMY_TARGET        = 24648,
 
     SAY_CRUSHER_AGGRO           = 0,
     SAY_CRUSHER_EMOTE           = 1,
@@ -152,6 +153,13 @@ const Position addWaypoints[ADD_WAYPOINT_COUNT] =
 };
 
 const Position ADD_SPAWN3_JOIN_WP = {609.41376f, 574.623f, 722.0532f, 0.0f};
+
+const Position webDummyPositions[3] =
+{
+    {583.8375f,  606.46747f, 739.3754f,  1.6401535f},
+    {577.10364f, 612.30005f, 771.4738f,  0.60115397f},
+    {482.53622f, 617.4355f,  771.92834f, 2.1164744f}
+};
 
 namespace HadronoxAddSlots
 {
@@ -367,7 +375,21 @@ struct npc_hadronox_addAI : public ScriptedAI
             }
         }
 
-        if (!_spawnedAbove735 || _reachedHadronox || _attackedByPlayer)
+        if (_reachedHadronox && !_attackedByPlayer)
+        {
+            Creature* hadronox = FindHadronox();
+            if (hadronox)
+            {
+                float dist = me->GetExactDist(hadronox);
+                if (me->isMoving() && dist <= 3.0f)
+                    me->GetMotionMaster()->Clear();
+                else if (!me->isMoving() && dist > 8.0f)
+                    MoveTowardHadronox(hadronox);
+            }
+            return;
+        }
+
+        if (!_spawnedAbove735 || _attackedByPlayer)
             return;
 
         Creature* hadronox = FindHadronox();
@@ -670,6 +692,8 @@ public:
             _reachedFinalWaypoint = false;
             _leashPos = {0.0f, 0.0f, 0.0f, 0.0f};
             _leashCheckTimer = 0;
+            _webDoorPhase = 0;
+            _dummiesSpawned = false;
         }
 
         bool _walkStarted;
@@ -679,12 +703,15 @@ public:
         bool _crusherAggroSaid;
         bool _waitingForNextStep;
         bool _reachedFinalWaypoint;
+        bool _dummiesSpawned;
         int32 _currentStep;
         uint32 _spawnCount;
         uint32 _movementCheckTimer;
         uint32 _leashCheckTimer;
+        uint32 _webDoorPhase;
         Position _lastPos;
         Position _leashPos;
+        ObjectGuid _webDummyGuids[3];
 
         void Reset() override
         {
@@ -702,6 +729,10 @@ public:
             _reachedFinalWaypoint = false;
             _leashPos = {0.0f, 0.0f, 0.0f, 0.0f};
             _leashCheckTimer = 0;
+            _webDoorPhase = 0;
+            _dummiesSpawned = false;
+            for (int i = 0; i < 3; ++i)
+                _webDummyGuids[i].Clear();
             _lastPos = me->GetPosition();
             me->SummonCreature(NPC_ANUB_AR_CRUSHER, 531.5281f, 553.8509f, 732.56f, 5.053f);
             me->SummonCreature(NPC_ANUB_AR_CRYPTFIEND, 524.07886f, 550.6797f, 731.873f, 5.053f);
@@ -709,14 +740,39 @@ public:
             events.ScheduleEvent(EVENT_HADRONOX_CHECK, 1s);
         }
 
+        void SpawnWebDummies()
+        {
+            if (_dummiesSpawned)
+                return;
+            _dummiesSpawned = true;
+            for (int i = 0; i < 3; ++i)
+            {
+                if (Creature* dummy = me->SummonCreature(NPC_WEB_DUMMY_TARGET,
+                    webDummyPositions[i].GetPositionX(),
+                    webDummyPositions[i].GetPositionY(),
+                    webDummyPositions[i].GetPositionZ(),
+                    webDummyPositions[i].GetOrientation(),
+                    TEMPSUMMON_MANUAL_DESPAWN))
+                {
+                    _webDummyGuids[i] = dummy->GetGUID();
+                    dummy->SetReactState(REACT_PASSIVE);
+                    dummy->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+                }
+            }
+        }
+
         void MoveToWaypoint(int32 index)
         {
             if (index < 0 || index >= 8)
                 return;
             if (index == 6)
-                me->CastSpell(me, SPELL_WEB_FRONT_DOORS, true);
+            {
+                _webDoorPhase = 1;
+                me->CastSpell(me, SPELL_WEB_SIDE_DOORS, true);
+            }
             if (index == 7)
             {
+                _webDoorPhase = 2;
                 me->CastSpell(me, SPELL_WEB_SIDE_DOORS, true);
                 _spawnsActive = false;
                 events.CancelEvent(EVENT_HADRONOX_SUMMON_ADD);
@@ -736,6 +792,7 @@ public:
             _walkStarted = true;
             instance->SetBossState(DATA_HADRONOX, IN_PROGRESS);
             me->setActive(true);
+            SpawnWebDummies();
             events.ScheduleEvent(EVENT_HADRONOX_STEP, 10s);
         }
 
@@ -792,7 +849,16 @@ public:
         {
             if (data == me->GetEntry())
                 return (_currentStep < 7) ? 1 : 0;
+            if (data == 0xDEAD1)
+                return _webDoorPhase;
             return 0;
+        }
+
+        ObjectGuid GetWebDummyGuid(uint32 index) const
+        {
+            if (index < 3)
+                return _webDummyGuids[index];
+            return ObjectGuid::Empty;
         }
 
         void JustSummoned(Creature* summon) override
@@ -986,6 +1052,19 @@ public:
                         {
                             _reachedFinalWaypoint = true;
                             _leashPos = me->GetPosition();
+                            Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+                            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+                            {
+                                Player* player = itr->GetSource();
+                                if (!player || !player->IsAlive() || player->IsGameMaster())
+                                    continue;
+                                if (me->GetExactDist(player) <= 40.0f)
+                                {
+                                    me->AddThreat(player, 1.0f);
+                                    me->SetInCombatWith(player);
+                                    player->SetInCombatWith(me);
+                                }
+                            }
                         }
                     }
                     else if (!_waitingForNextStep)
@@ -1386,6 +1465,61 @@ class spell_hadronox_leech_poison_aura : public AuraScript
     }
 };
 
+class spell_hadronox_web_side_doors : public SpellScript
+{
+    PrepareSpellScript(spell_hadronox_web_side_doors);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        Unit* caster = GetCaster();
+        if (!caster)
+        {
+            targets.clear();
+            return;
+        }
+
+        Creature* hadronox = caster->ToCreature();
+        if (!hadronox)
+        {
+            targets.clear();
+            return;
+        }
+
+        uint32 phase = hadronox->AI()->GetData(0xDEAD1);
+
+        targets.remove_if([hadronox, phase](WorldObject* obj) -> bool
+        {
+            Creature* creature = obj->ToCreature();
+            if (!creature || creature->GetEntry() != NPC_WEB_DUMMY_TARGET)
+                return true;
+
+            ObjectGuid guid = creature->GetGUID();
+
+            if (phase == 1)
+            {
+                boss_hadronox::boss_hadronoxAI* ai = dynamic_cast<boss_hadronox::boss_hadronoxAI*>(hadronox->AI());
+                if (!ai)
+                    return true;
+                return guid != ai->GetWebDummyGuid(0);
+            }
+            else if (phase == 2)
+            {
+                boss_hadronox::boss_hadronoxAI* ai = dynamic_cast<boss_hadronox::boss_hadronoxAI*>(hadronox->AI());
+                if (!ai)
+                    return true;
+                return guid != ai->GetWebDummyGuid(1) && guid != ai->GetWebDummyGuid(2);
+            }
+
+            return true;
+        });
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hadronox_web_side_doors::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENTRY);
+    }
+};
+
 class achievement_hadronox_denied : public AchievementCriteriaScript
 {
 public:
@@ -1410,5 +1544,6 @@ void AddSC_boss_hadronox()
     new boss_hadronox();
     new npc_anub_ar_crusher();
     RegisterSpellScript(spell_hadronox_leech_poison_aura);
+    RegisterSpellScript(spell_hadronox_web_side_doors);
     new achievement_hadronox_denied();
 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -85,23 +85,23 @@ enum Misc
     SAY_CRUSHER_EMOTE           = 1,
     SAY_HADRONOX_EMOTE          = 0,
 
-    // ACTION_DESPAWN_ADDS         = 1,
     ACTION_START_EVENT          = 2,
     ACTION_START_WALK           = 3,
     ACTION_STOP_SPAWNS          = 4,
     ACTION_CRUSHER_EVADE        = 5
 };
 
-constexpr float GAUNTLET_END_Z     = 640.0f;
-constexpr float GAUNTLET_START_Z   = 730.0f;
-constexpr float STEP_REACH         = 3.0f;
-constexpr float STEP_SPEED         = 5.0f;
-constexpr float ADDS_RANGE         = 8.0f;
-constexpr float SPELL_MAX_DIST     = 40.0f;
-constexpr float SPELL_MAX_Z_DIFF   = 20.0f;
-const Position HADRONOX_SPAWN_POS  = {522.531f, 544.911f, 674.679f, 0.0f};
+constexpr float GAUNTLET_END_Z   = 640.0f;
+constexpr float GAUNTLET_START_Z = 730.0f;
+constexpr float STEP_REACH       = 3.0f;
+constexpr float STEP_SPEED       = 3.5f;
+constexpr float ADDS_RANGE       = 8.0f;
+constexpr float SPELL_MAX_DIST   = 40.0f;
+constexpr float SPELL_MAX_Z_DIFF = 20.0f;
+constexpr float WAYPOINT_REACH   = 1.0f;
+constexpr uint32 ADD_CHECK_MS    = 100;
+const Position HADRONOX_SPAWN_POS = {522.531f, 544.911f, 674.679f, 0.0f};
 
-// Indices 0-3: start waypoints (approach phase), indices 4-7: combat steps
 const Position hadronoxWaypoints[8] =
 {
     {533.5879f,  533.34607f, 681.70135f, 0.0f},
@@ -120,16 +120,24 @@ const Position addSpawnPos[2] =
     {483.68f, 612.75f, 771.42f, 0.0f}
 };
 
-const Position addWaypoints[8] =
+constexpr uint32 ADD_WAYPOINT_COUNT = 15;
+const Position addWaypoints[ADD_WAYPOINT_COUNT] =
 {
-    {531.00f, 573.00f, 733.00f, 0.0f},
-    {546.76f, 563.00f, 730.87f, 0.0f},
-    {585.83f, 577.74f, 726.00f, 0.0f},
-    {610.95f, 565.35f, 719.56f, 0.0f},
-    {620.81f, 531.21f, 700.74f, 0.0f},
-    {604.28f, 510.95f, 694.65f, 0.0f},
-    {559.21f, 512.35f, 695.00f, 0.0f},
-    {522.53f, 544.91f, 674.68f, 0.0f}
+    {530.65857f, 576.39716f, 733.4407f,  0.0f},
+    {544.5423f,  568.7522f,  731.1956f,  0.0f},
+    {553.83936f, 568.7116f,  729.4889f,  0.0f},
+    {561.3301f,  572.9708f,  728.1504f,  0.0f},
+    {571.4326f,  573.8239f,  727.1494f,  0.0f},
+    {585.2161f,  576.30334f, 726.0641f,  0.0f},
+    {597.7994f,  572.25964f, 723.12836f, 0.0f},
+    {608.68f,    554.1495f,  714.67725f, 0.0f},
+    {620.7482f,  539.47156f, 706.5057f,  0.0f},
+    {620.7156f,  528.55646f, 698.867f,   0.0f},
+    {603.81274f, 510.69556f, 694.7088f,  0.0f},
+    {586.75836f, 512.0464f,  695.60925f, 0.0f},
+    {566.58093f, 514.4511f,  698.7215f,  0.0f},
+    {552.9107f,  523.64606f, 688.75604f, 0.0f},
+    {540.6518f,  532.722f,   684.9354f,  0.0f}
 };
 
 static bool IsValidSpellTarget(Unit* caster, WorldObject* target)
@@ -151,14 +159,16 @@ struct npc_hadronox_addAI : public ScriptedAI
         _reachedHadronox = false;
         _attackedByPlayer = false;
         _spawnedAbove745 = creature->GetPositionZ() >= 745.0f;
-        _lastPos = creature->GetPosition();
+        _chasingHadronox = false;
+        _checkTimer = 0;
     }
 
     uint32 _currentWaypoint;
     bool _reachedHadronox;
     bool _attackedByPlayer;
     bool _spawnedAbove745;
-    Position _lastPos;
+    bool _chasingHadronox;
+    uint32 _checkTimer;
     EventMap events;
 
     bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
@@ -168,27 +178,64 @@ struct npc_hadronox_addAI : public ScriptedAI
         _currentWaypoint = 0;
         _reachedHadronox = false;
         _attackedByPlayer = false;
-        _lastPos = me->GetPosition();
+        _chasingHadronox = false;
+        _checkTimer = 0;
         events.Reset();
         if (_spawnedAbove745)
-            MoveToNextWaypoint();
+            IssueMove();
     }
 
-    void MoveToNextWaypoint()
+    Creature* FindHadronox() const
     {
-        if (_currentWaypoint >= 8)
-            return;
-        me->GetMotionMaster()->MovePoint(_currentWaypoint, addWaypoints[_currentWaypoint]);
+        return me->FindNearestCreature(NPC_HADRONOX, 500.0f, true);
     }
 
-    void MovementInform(uint32 type, uint32 id) override
+    void MoveTowardHadronox(Creature* hadronox)
     {
-        if (type != POINT_MOTION_TYPE || _reachedHadronox || _attackedByPlayer)
-            return;
+        me->GetMotionMaster()->MovePoint(0, hadronox->GetPositionX(), hadronox->GetPositionY(), hadronox->GetPositionZ(), FORCED_MOVEMENT_RUN);
+    }
 
-        _currentWaypoint = id + 1;
-        if (_currentWaypoint < 8)
-            MoveToNextWaypoint();
+    void EngageHadronox(Creature* hadronox)
+    {
+        _reachedHadronox = true;
+        _chasingHadronox = false;
+        me->SetReactState(REACT_AGGRESSIVE);
+        AttackStart(hadronox);
+        ScheduleCombatEvents();
+    }
+
+    // Issues MovePoint to current waypoint, or MovePoint to Hadronox if closer.
+    void IssueMove()
+    {
+        Creature* hadronox = FindHadronox();
+
+        if (hadronox)
+        {
+            float distToHadronox = me->GetExactDist(hadronox);
+            if (distToHadronox <= ADDS_RANGE)
+            {
+                EngageHadronox(hadronox);
+                return;
+            }
+
+            const Position& nextWp = addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT];
+            float distToNext = me->GetExactDist(nextWp);
+
+            if (distToHadronox < distToNext)
+            {
+                _chasingHadronox = true;
+                MoveTowardHadronox(hadronox);
+                return;
+            }
+        }
+
+        _chasingHadronox = false;
+        me->GetMotionMaster()->MovePoint(
+            _currentWaypoint,
+            addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT].GetPositionX(),
+            addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT].GetPositionY(),
+            addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT].GetPositionZ(),
+            FORCED_MOVEMENT_RUN);
     }
 
     void DamageTaken(Unit* who, uint32& /*damage*/, DamageEffectType /*damageType*/, SpellSchoolMask /*damageSchoolMask*/) override
@@ -197,6 +244,7 @@ struct npc_hadronox_addAI : public ScriptedAI
         {
             _attackedByPlayer = true;
             _reachedHadronox = false;
+            _chasingHadronox = false;
             me->GetMotionMaster()->Clear();
             me->SetReactState(REACT_AGGRESSIVE);
             if (who->IsPlayer())
@@ -205,51 +253,85 @@ struct npc_hadronox_addAI : public ScriptedAI
         }
     }
 
-    void JustEngagedWith(Unit* /*who*/) override
-    {
-    }
+    void JustEngagedWith(Unit* /*who*/) override {}
 
     virtual void ScheduleCombatEvents() = 0;
 
     bool NearHadronox() const
     {
-        if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, ADDS_RANGE, true))
-            return true;
-        return false;
-    }
-
-    void UpdateWalk(uint32 /*diff*/)
-    {
-        if (_reachedHadronox || _attackedByPlayer)
-            return;
-
-        if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
-        {
-            float zDiff = std::abs(me->GetPositionZ() - hadronox->GetPositionZ());
-            if (zDiff <= ADDS_RANGE)
-            {
-                _reachedHadronox = true;
-                me->SetReactState(REACT_AGGRESSIVE);
-                me->GetMotionMaster()->Clear();
-                me->GetMotionMaster()->MoveChase(hadronox);
-                AttackStart(hadronox);
-                ScheduleCombatEvents();
-                return;
-            }
-        }
-
-        if (_spawnedAbove745)
-        {
-            float movedDist = me->GetExactDist(_lastPos.GetPositionX(), _lastPos.GetPositionY(), _lastPos.GetPositionZ());
-            if (movedDist < 0.1f && _currentWaypoint < 8)
-                MoveToNextWaypoint();
-            _lastPos = me->GetPosition();
-        }
+        return me->FindNearestCreature(NPC_HADRONOX, ADDS_RANGE, true) != nullptr;
     }
 
     bool ShouldUseCombatAbilities() const
     {
         return _attackedByPlayer || NearHadronox();
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!_spawnedAbove745 || _reachedHadronox || _attackedByPlayer)
+            return;
+
+        Creature* hadronox = FindHadronox();
+
+        if (hadronox && me->GetExactDist(hadronox) <= ADDS_RANGE)
+        {
+            EngageHadronox(hadronox);
+            return;
+        }
+
+        if (_chasingHadronox && hadronox)
+        {
+            float dist = me->GetExactDist(hadronox);
+            if (dist <= 4.0f)
+                me->GetMotionMaster()->Clear();
+            else if (dist >= 7.0f)
+                MoveTowardHadronox(hadronox);
+            return;
+        }
+
+        // Advance waypoint if reached
+        const Position& wp = addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT];
+        if (me->GetExactDist(wp) <= WAYPOINT_REACH)
+            _currentWaypoint++;
+
+        if (!me->isMoving())
+        {
+            me->GetMotionMaster()->MovePoint(
+                _currentWaypoint,
+                addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT].GetPositionX(),
+                addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT].GetPositionY(),
+                addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT].GetPositionZ(),
+                FORCED_MOVEMENT_RUN);
+        }
+
+        _checkTimer += diff;
+        if (_checkTimer < ADD_CHECK_MS)
+            return;
+        _checkTimer = 0;
+
+        if (!hadronox)
+            return;
+
+        // Special case: reached waypoint 0 and Hadronox is already high
+        if (_currentWaypoint == 0
+            && me->GetExactDist(addWaypoints[0]) <= WAYPOINT_REACH
+            && hadronox->GetPositionZ() > 729.0f)
+        {
+            _currentWaypoint = 1;
+            _chasingHadronox = true;
+            MoveTowardHadronox(hadronox);
+            return;
+        }
+
+        float distToHadronox = me->GetExactDist(hadronox);
+        const Position& nextWp = addWaypoints[_currentWaypoint % ADD_WAYPOINT_COUNT];
+        float distToNext = me->GetExactDist(nextWp);
+        if (distToHadronox < distToNext)
+        {
+            _chasingHadronox = true;
+            MoveTowardHadronox(hadronox);
+        }
     }
 };
 
@@ -275,7 +357,7 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            UpdateWalk(diff);
+            npc_hadronox_addAI::UpdateAI(diff);
 
             if (_spawnedAbove745 && !ShouldUseCombatAbilities())
                 me->SetReactState(REACT_PASSIVE);
@@ -343,7 +425,7 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            UpdateWalk(diff);
+            npc_hadronox_addAI::UpdateAI(diff);
 
             if (_spawnedAbove745 && !ShouldUseCombatAbilities())
                 me->SetReactState(REACT_PASSIVE);
@@ -411,7 +493,7 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            UpdateWalk(diff);
+            npc_hadronox_addAI::UpdateAI(diff);
 
             if (_spawnedAbove745 && !ShouldUseCombatAbilities())
                 me->SetReactState(REACT_PASSIVE);
@@ -555,6 +637,13 @@ public:
                 me->AI()->EnterEvadeMode();
         }
 
+        void EnterEvadeMode(EvadeReason /*why*/) override
+        {
+            if (_spawnsActive && AnyPlayerInHadronoxGauntlet())
+                return;
+            BossAI::EnterEvadeMode();
+        }
+
         uint32 GetData(uint32 data) const override
         {
             if (data == me->GetEntry())
@@ -654,7 +743,7 @@ public:
                     continue;
                 float z = player->GetPositionZ();
                 float y = player->GetPositionY();
-                if (y < 625.0f && z > GAUNTLET_END_Z)
+                if (player->IsAlive() && y < 625.0f && z > GAUNTLET_END_Z)
                     return true;
             }
             return false;
@@ -740,17 +829,6 @@ public:
                 {
                     if (me->GetExactDist(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ()) > 2.0f)
                         me->GetMotionMaster()->MovePoint(0, HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ(), FORCED_MOVEMENT_NONE, 0.f, 0.f, false);
-
-                    std::list<Creature*> addList;
-                    for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
-                    {
-                        std::list<Creature*> tmp;
-                        me->GetCreaturesWithEntryInRange(tmp, 500.0f, entry);
-                        addList.splice(addList.end(), tmp);
-                    }
-                    for (Creature* add : addList)
-                        if (add->GetExactDist(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ()) > ADDS_RANGE)
-                            add->GetMotionMaster()->MoveChase(me);
                 }
             }
 
@@ -857,16 +935,6 @@ public:
             summons.DespawnAll();
             events.Reset();
             _eventStarted = false;
-        }
-
-        void JustSummoned(Creature* summon) override
-        {
-            if (summon->GetEntry() != me->GetEntry())
-            {
-                summon->GetMotionMaster()->MovePoint(0, *me, FORCED_MOVEMENT_NONE, 0.f, false);
-                summon->GetMotionMaster()->MoveFollow(me, 0.1f, 0.0f + M_PI * 0.3f * summons.size());
-            }
-            summons.Summon(summon);
         }
 
         void JustEngagedWith(Unit*) override

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -308,6 +308,28 @@ struct npc_hadronox_addAI : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
+        if (_attackedByPlayer)
+        {
+            bool hasPlayerThreat = false;
+            ThreatMgr& mgr = me->GetThreatMgr();
+            for (auto* ref : mgr.GetThreatList())
+            {
+                if (ref->GetVictim() && ref->GetVictim()->IsControlledByPlayer())
+                {
+                    hasPlayerThreat = true;
+                    break;
+                }
+            }
+            if (!hasPlayerThreat)
+            {
+                _attackedByPlayer = false;
+                me->SetReactState(REACT_PASSIVE);
+                me->AttackStop();
+                me->GetThreatMgr().ClearAllThreat();
+                IssueMove();
+            }
+        }
+
         if (!_spawnedAbove735 || _reachedHadronox || _attackedByPlayer)
             return;
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1228,7 +1228,7 @@ public:
         npc_anub_ar_crusherAI(Creature* c) : ScriptedAI(c), summons(me)
         {
             _eventStarted = false;
-            _isSpawnedCrusher = false;
+            _isSpawnedCrusher = me->ToTempSummon() && me->ToTempSummon()->GetSummonerUnit() && me->ToTempSummon()->GetSummonerUnit()->GetEntry() == NPC_ANUB_AR_CRUSHER;
             _pathStep = 0;
             _pathCheckTimer = 0;
             _finalDest = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -1254,11 +1254,6 @@ public:
         void JustSummoned(Creature* summon) override
         {
             summons.Summon(summon);
-        }
-
-        void SetData(uint32 /*id*/, uint32 /*value*/) override
-        {
-            _isSpawnedCrusher = true;
         }
 
         void SetDestination(const Position& dest)
@@ -1350,11 +1345,9 @@ public:
                     const Position& assignDest1 = (c1DistToDest1 <= c1DistToDest2) ? dest1 : dest2;
                     const Position& assignDest2 = (c1DistToDest1 <= c1DistToDest2) ? dest2 : dest1;
 
-                    c1->AI()->SetData(0, 0);
                     static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(assignDest1);
                     static_cast<npc_anub_ar_crusherAI*>(c1->AI())->ScheduleAddSpawns();
 
-                    c2->AI()->SetData(0, 0);
                     static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(assignDest2);
                     static_cast<npc_anub_ar_crusherAI*>(c2->AI())->ScheduleAddSpawns();
                 }
@@ -1362,13 +1355,11 @@ public:
                 {
                     if (c1)
                     {
-                        c1->AI()->SetData(0, 0);
                         static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(dest1);
                         static_cast<npc_anub_ar_crusherAI*>(c1->AI())->ScheduleAddSpawns();
                     }
                     if (c2)
                     {
-                        c2->AI()->SetData(0, 0);
                         static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(dest2);
                         static_cast<npc_anub_ar_crusherAI*>(c2->AI())->ScheduleAddSpawns();
                     }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1044,6 +1044,8 @@ public:
                                 Talk(SAY_HADRONOX_EMOTE);
                                 _waitingForNextStep = true;
                                 events.ScheduleEvent(EVENT_HADRONOX_NEXT_WAYPOINT, 15s);
+                                if (Aura* aura = me->AddAura(35340, me))
+                                    aura->SetDuration(15000);
                             }
                             else
                                 MoveToWaypoint(_currentStep);
@@ -1129,6 +1131,7 @@ public:
                     break;
                 case EVENT_HADRONOX_NEXT_WAYPOINT:
                     _waitingForNextStep = false;
+                    me->RemoveAurasDueToSpell(35340);
                     if (_currentStep < 8)
                         MoveToWaypoint(_currentStep);
                     break;

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1145,6 +1145,18 @@ public:
         {
             events.Update(diff);
 
+            for (ObjectGuid guid : summons)
+            {
+                Creature* summon = ObjectAccessor::GetCreature(*me, guid);
+                if (!summon || !summon->IsAlive())
+                    continue;
+                if (me->GetPositionZ() - summon->GetPositionZ() < 30.0f || summon->GetPositionZ() >= 720.0f)
+                    continue;
+                if (summon->GetVictim() != me)
+                    continue;
+                summon->DespawnOrUnsummon();
+            }
+
             _movementCheckTimer += diff;
             if (_movementCheckTimer >= 200)
             {

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -90,8 +90,8 @@ enum Misc
     NPC_ANUB_AR_CRUSHER         = 28922,
     NPC_WEB_DUMMY_TARGET        = 24648,
 
-    SAY_CRUSHER_AGGRO           = 0,
-    SAY_CRUSHER_EMOTE           = 1,
+    SAY_CRUSHER_AGGRO           = 1,
+    SAY_CRUSHER_EMOTE           = 2,
     SAY_HADRONOX_EMOTE          = 0,
 
     ACTION_START_EVENT          = 2,
@@ -103,6 +103,7 @@ enum Misc
 
 constexpr float GAUNTLET_END_Z        = 640.0f;
 constexpr float GAUNTLET_START_Z      = 730.0f;
+constexpr float GAUNTLET_MAX_Y        = 625.0f;
 constexpr float STEP_REACH            = 3.0f;
 constexpr float STEP_SPEED            = 4.5f;
 constexpr float ADDS_RANGE            = 8.0f;
@@ -823,7 +824,7 @@ public:
 
         void EnterEvadeMode(EvadeReason /*why*/) override
         {
-            if (_spawnsActive && AnyPlayerInHadronoxGauntlet())
+            if (AnyPlayerInHadronoxGauntlet())
                 return;
             BossAI::EnterEvadeMode();
         }
@@ -922,7 +923,7 @@ public:
                 Player* player = itr->GetSource();
                 if (!player || player->IsGameMaster())
                     continue;
-                if (player->GetPositionY() < 625.0f && player->GetPositionZ() > GAUNTLET_END_Z && player->GetPositionZ() < GAUNTLET_START_Z)
+                if (player->GetPositionY() < GAUNTLET_MAX_Y && player->GetPositionZ() > GAUNTLET_END_Z && player->GetPositionZ() < GAUNTLET_START_Z)
                     return true;
             }
             return false;
@@ -938,7 +939,7 @@ public:
                     continue;
                 float z = player->GetPositionZ();
                 float y = player->GetPositionY();
-                if (player->IsAlive() && y < 625.0f && z > GAUNTLET_END_Z)
+                if (player->IsAlive() && y < GAUNTLET_MAX_Y && z > GAUNTLET_END_Z)
                     return true;
             }
             return false;
@@ -1044,7 +1045,9 @@ public:
                                 Player* player = itr->GetSource();
                                 if (!player || !player->IsAlive() || player->IsGameMaster())
                                     continue;
-                                if (me->GetExactDist(player) <= 40.0f)
+                                float z = player->GetPositionZ();
+                                float y = player->GetPositionY();
+                                if (y < GAUNTLET_MAX_Y && z > GAUNTLET_END_Z)
                                 {
                                     me->AddThreat(player, 1.0f);
                                     me->SetInCombatWith(player);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1026,7 +1026,6 @@ public:
                         {
                             if (_currentStep >= 4)
                             {
-                                Talk(SAY_HADRONOX_EMOTE);
                                 _waitingForNextStep = true;
                                 events.ScheduleEvent(EVENT_HADRONOX_NEXT_WAYPOINT, 15s);
                                 if (Aura* aura = me->AddAura(35340, me))
@@ -1138,6 +1137,7 @@ public:
                 case EVENT_HADRONOX_NEXT_WAYPOINT:
                     _waitingForNextStep = false;
                     me->RemoveAurasDueToSpell(35340);
+                    Talk(SAY_HADRONOX_EMOTE);
                     if (_currentStep < 8)
                         MoveToWaypoint(_currentStep);
                     break;

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -244,6 +244,11 @@ struct npc_hadronox_addAI : public ScriptedAI
         }
     }
 
+    void JustDespawned() override
+    {
+        ReleaseSlot();
+    }
+
     Creature* FindHadronox() const
     {
         return me->FindNearestCreature(NPC_HADRONOX, 500.0f, true);
@@ -1138,6 +1143,16 @@ public:
                 _pathStep = 0;
         }
 
+        void JustSummoned(Creature* summon) override
+        {
+            summons.Summon(summon);
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            summons.DespawnAll();
+        }
+
         void SetData(uint32 /*id*/, uint32 /*value*/) override
         {
             _isSpawnedCrusher = true;
@@ -1258,6 +1273,7 @@ public:
 
         void EnterEvadeMode(EvadeReason /*why*/) override
         {
+            summons.DespawnAll();
             if (!_isSpawnedCrusher)
             {
                 if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -915,11 +915,19 @@ public:
             if (!_spawnsActive)
                 return;
             uint32 spawnIndex = _spawnCount % 3;
+            _spawnCount++;
+            if (spawnIndex == 2)
+            {
+                std::list<Creature*> dummies;
+                me->GetCreaturesWithEntryInRange(dummies, 200.0f, NPC_WEB_DUMMY_TARGET);
+                for (Creature* dummy : dummies)
+                    if (dummy->HasAura(SPELL_WEB_SIDE_DOORS))
+                        return;
+            }
             Position pos = addSpawnPos[spawnIndex];
             Creature* add = me->SummonCreature(entry, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
             if (add)
                 add->AI()->SetData(0, spawnIndex);
-            _spawnCount++;
         }
 
         void DoAction(int32 param) override

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -432,7 +432,14 @@ struct npc_hadronox_addAI : public ScriptedAI
             else if (_crusherPathStep == 2)
             {
                 if (me->GetExactDist(_crusherSlotPos) <= WAYPOINT_REACH)
+                {
                     _crusherPathStep = 0;
+
+                    if (Creature* nearestCrusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 10.0f, true))
+                        me->SetFacingTo(nearestCrusher->GetOrientation());
+                    else
+                        me->SetFacingTo(-1.4f);
+                }
                 else if (!me->isMoving())
                 {
                     me->GetMotionMaster()->MovePoint(1,

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1005,7 +1005,10 @@ public:
                 }
 
                 for (Unit* target : targets)
+                {
                     me->CastSpell(target, SPELL_WEB_GRAB_OVERRIDE, false);
+                    me->AddThreat(target, 1.0f);
+                }
             }
             else
             {

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1144,11 +1144,6 @@ public:
             summons.Summon(summon);
         }
 
-        void JustDied(Unit* /*killer*/) override
-        {
-            summons.DespawnAll();
-        }
-
         void SetData(uint32 /*id*/, uint32 /*value*/) override
         {
             _isSpawnedCrusher = true;

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -34,7 +34,7 @@ enum Spells
     SPELL_ACID_CLOUD                        = 53400,
     SPELL_LEECH_POISON                      = 53030,
     SPELL_LEECH_POISON_HEAL                 = 53800,
-    SPELL_WEB_GRAB                          = 57731,
+    SPELL_WEB_GRAB                          = 56640,
     SPELL_PIERCE_ARMOR                      = 53418,
 
     SPELL_SMASH                             = 53318,
@@ -198,6 +198,7 @@ struct npc_hadronox_addAI : public ScriptedAI
             _attackedByPlayer = true;
             _reachedHadronox = false;
             me->GetMotionMaster()->Clear();
+            me->SetReactState(REACT_AGGRESSIVE);
             if (who->IsPlayer())
                 AttackStart(who);
             ScheduleCombatEvents();
@@ -228,6 +229,7 @@ struct npc_hadronox_addAI : public ScriptedAI
             if (zDiff <= ADDS_RANGE)
             {
                 _reachedHadronox = true;
+                me->SetReactState(REACT_AGGRESSIVE);
                 me->GetMotionMaster()->Clear();
                 me->GetMotionMaster()->MoveChase(hadronox);
                 AttackStart(hadronox);
@@ -668,6 +670,39 @@ public:
             return false;
         }
 
+        void CastWebGrabOnValidTargets()
+        {
+            std::list<Unit*> targets;
+
+            Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+            {
+                Player* player = itr->GetSource();
+                if (!player || !player->IsAlive() || player->IsGameMaster())
+                    continue;
+                if (!IsValidSpellTarget(me, player))
+                    continue;
+                targets.push_back(player);
+            }
+
+            for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
+            {
+                std::list<Creature*> cl;
+                me->GetCreaturesWithEntryInRange(cl, SPELL_MAX_DIST, entry);
+                for (Creature* c : cl)
+                {
+                    if (!c->IsAlive())
+                        continue;
+                    if (!IsValidSpellTarget(me, c))
+                        continue;
+                    targets.push_back(c);
+                }
+            }
+
+            for (Unit* target : targets)
+                me->CastSpell(target, SPELL_WEB_GRAB, false);
+        }
+
         void UpdateAI(uint32 diff) override
         {
             events.Update(diff);
@@ -705,7 +740,7 @@ public:
                 {
                     if (me->GetExactDist(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ()) > 2.0f)
                         me->GetMotionMaster()->MovePoint(0, HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ(), FORCED_MOVEMENT_NONE, 0.f, 0.f, false);
-                    
+
                     std::list<Creature*> addList;
                     for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
                     {
@@ -778,8 +813,8 @@ public:
                     break;
                 case EVENT_HADRONOX_GRAB:
                     if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
-                        me->CastSpell(me, SPELL_WEB_GRAB, false);
-                    events.ScheduleEvent(EVENT_HADRONOX_GRAB, 25s);
+                        CastWebGrabOnValidTargets();
+                    events.ScheduleEvent(EVENT_HADRONOX_GRAB, 12s);
                     break;
             }
 
@@ -926,29 +961,6 @@ public:
     }
 };
 
-class spell_hadronox_web_grab : public SpellScript
-{
-    PrepareSpellScript(spell_hadronox_web_grab);
-
-    void FilterTargets(std::list<WorldObject*>& targets)
-    {
-        Unit* caster = GetCaster();
-        targets.remove_if([caster](WorldObject* target) -> bool
-        {
-            if (caster->GetExactDist(target) > SPELL_MAX_DIST)
-                return true;
-            if (std::abs(caster->GetPositionZ() - target->GetPositionZ()) > SPELL_MAX_Z_DIFF)
-                return true;
-            return false;
-        });
-    }
-
-    void Register() override
-    {
-        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hadronox_web_grab::FilterTargets, EFFECT_ALL, TARGET_UNIT_SRC_AREA_ENEMY);
-    }
-};
-
 void AddSC_boss_hadronox()
 {
     new npc_anub_ar_champion();
@@ -957,6 +969,5 @@ void AddSC_boss_hadronox()
     new boss_hadronox();
     new npc_anub_ar_crusher();
     RegisterSpellScript(spell_hadronox_leech_poison_aura);
-    RegisterSpellScript(spell_hadronox_web_grab);
     new achievement_hadronox_denied();
 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -25,7 +25,7 @@
 #include "SpellScript.h"
 
 // Configs
-constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = false;  // Blizzlike is false, true is more akin to other pservers
+constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = false; // Blizzlike is false, true is more akin to other pservers
 constexpr bool CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER      = false; // true = on player entering gauntlet (y < 625), false = on crusher engaged. Blizzlike is false
 constexpr bool WEB_GRAB_OVERRIDE                        = true;  // Emulate web grab by using range-locked single target spell looping through and grabbing valid targets in range. Sniffed spell has too long range and grabs through floor. Blizzlike is false but bugged
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -26,6 +26,7 @@
 
 // Configs
 constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = false; // Blizzlike is false, true is more akin to other pservers
+constexpr bool HADRONOX_STOP_ASCENT_ON_PLAYER_DAMAGE    = true;  // Blizzlike is true
 constexpr bool CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER      = false; // true = on player entering gauntlet (y < 625), false = on crusher engaged. Blizzlike is false
 constexpr bool WEB_GRAB_OVERRIDE                        = true;  // Emulate web grab by using range-locked single target spell looping through and grabbing valid targets in range. Sniffed spell has too long range and grabs through floor. Blizzlike is false but bugged
 
@@ -894,6 +895,13 @@ public:
             {
                 _playerAttacked = true;
 
+                if (HADRONOX_STOP_ASCENT_ON_PLAYER_DAMAGE)
+                {
+                    me->GetMotionMaster()->Clear();
+                    _waitingForNextStep = false;
+                    me->RemoveAurasDueToSpell(35340);
+                }
+
                 if (PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS)
                 {
                     _spawnsActive = false;
@@ -1088,21 +1096,40 @@ public:
                 }
             }
 
-            if (_reachedFinalWaypoint && !_playerAttacked && me->IsInCombat())
+            if (_reachedFinalWaypoint && me->IsInCombat())
             {
-                _leashCheckTimer += diff;
-                if (_leashCheckTimer >= HADRONOX_LEASH_CHECK)
+                bool fightingNpc = false;
+                for (auto* ref : me->GetThreatMgr().GetThreatList())
                 {
-                    _leashCheckTimer = 0;
-                    if (GetDistXY(me->GetPosition(), _leashPos) > HADRONOX_LEASH_RANGE)
+                    Unit* victim = ref->GetVictim();
+                    if (!victim)
+                        continue;
+                    uint32 entry = victim->GetEntry();
+                    if (entry == NPC_ANUB_AR_CRUSHER || entry == NPC_ANUB_AR_CHAMPION || entry == NPC_ANUB_AR_NECROMANCER || entry == NPC_ANUB_AR_CRYPTFIEND)
                     {
-                        me->GetMotionMaster()->MovePoint(0,
-                            _leashPos.GetPositionX(),
-                            _leashPos.GetPositionY(),
-                            _leashPos.GetPositionZ(),
-                            FORCED_MOVEMENT_RUN);
+                        fightingNpc = true;
+                        break;
                     }
                 }
+
+                if (fightingNpc)
+                {
+                    _leashCheckTimer += diff;
+                    if (_leashCheckTimer >= HADRONOX_LEASH_CHECK)
+                    {
+                        _leashCheckTimer = 0;
+                        if (GetDistXY(me->GetPosition(), _leashPos) > HADRONOX_LEASH_RANGE)
+                        {
+                            me->GetMotionMaster()->MovePoint(0,
+                                _leashPos.GetPositionX(),
+                                _leashPos.GetPositionY(),
+                                _leashPos.GetPositionZ(),
+                                FORCED_MOVEMENT_RUN);
+                        }
+                    }
+                }
+                else
+                    me->GetMotionMaster()->Clear();
             }
 
             switch (uint32 eventId = events.ExecuteEvent())
@@ -1289,7 +1316,12 @@ public:
 
         void JustEngagedWith(Unit*) override
         {
-            if (!_isSpawnedCrusher)
+            if (_isSpawnedCrusher)
+            {
+                _pathStep = 0;
+                me->GetMotionMaster()->Clear();
+            }
+            else
             {
                 if (!CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
                 {

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1095,8 +1095,16 @@ public:
                 else if (me->GetThreatMgr().GetThreatList().empty())
                     me->GetMotionMaster()->Clear();
                 else if (Unit* top = me->GetThreatMgr().GetCurrentVictim())
-                    if (!me->isMoving())
-                        me->GetMotionMaster()->MoveChase(top);
+                {
+                    Player* player = top->ToPlayer();
+                    if (player && player->GetPositionY() < GAUNTLET_MAX_Y && player->GetPositionZ() > GAUNTLET_END_Z)
+                    {
+                        if (!me->isMoving())
+                            me->GetMotionMaster()->MoveChase(top);
+                    }
+                    else
+                        me->AI()->EnterEvadeMode();
+                }
             }
 
             switch (uint32 eventId = events.ExecuteEvent())

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1094,6 +1094,9 @@ public:
                 }
                 else if (me->GetThreatMgr().GetThreatList().empty())
                     me->GetMotionMaster()->Clear();
+                else if (Unit* top = me->GetThreatMgr().GetCurrentVictim())
+                    if (!me->isMoving())
+                        me->GetMotionMaster()->MoveChase(top);
             }
 
             switch (uint32 eventId = events.ExecuteEvent())

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -987,11 +987,12 @@ public:
                     {
                         if (AnyPlayerInHadronoxGauntlet())
                         {
-                            if (!_crusherAggroSaid && CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
+                            if (!_crusherAggroSaid)
                             {
                                 _crusherAggroSaid = true;
-                                if (Creature* crusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 300.0f, true))
-                                    crusher->AI()->Talk(SAY_CRUSHER_AGGRO);
+                                if (CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER)
+                                    if (Creature* crusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 300.0f, true))
+                                        crusher->AI()->Talk(SAY_CRUSHER_AGGRO);
                                 StartSummonEvents();
                             }
                             if (!_walkStarted && AnyPlayerBelowWalkTrigger())

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -25,7 +25,7 @@
 #include "SpellScript.h"
 
 // Configs
-constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = true;  // Blizzlike is false
+constexpr bool PLAYER_DMG_ON_HADRONOX_STOPS_ADD_SUMMONS = false;  // Blizzlike is false, true is more akin to other pservers
 constexpr bool CRUSHER_AGGRO_SAY_ON_GAUNTLET_ENTER      = false; // true = on player entering gauntlet (y < 625), false = on crusher engaged. Blizzlike is false
 constexpr bool WEB_GRAB_OVERRIDE                        = true;  // Emulate web grab by using range-locked single target spell looping through and grabbing valid targets in range. Sniffed spell has too long range and grabs through floor. Blizzlike is false but bugged
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -74,6 +74,8 @@ enum Events
     EVENT_CHECK_HEALTH              = 21,
     EVENT_CRUSHER_SPAWN_ADD1        = 22,
     EVENT_CRUSHER_SPAWN_ADD2        = 23,
+    EVENT_CRUSHER_SPAWN_ADD3        = 24,
+    EVENT_CRUSHER_SPAWN_ADD4        = 25,
 
     EVENT_CHAMPION_REND             = 1,
     EVENT_CHAMPION_PUMMEL           = 2,
@@ -199,11 +201,17 @@ struct npc_hadronox_addAI : public ScriptedAI
         _reachedHadronox = false;
         _attackedByPlayer = false;
         _spawnedAbove735 = creature->GetPositionZ() >= 735.0f;
+        if (_spawnedAbove735)
+            if (TempSummon* ts = creature->ToTempSummon())
+                if (Unit* summoner = ts->GetSummonerUnit())
+                    _spawnedAbove735 = (summoner->GetEntry() == NPC_HADRONOX);
         _chasingHadronox = false;
         _checkTimer = 0;
         _spawnIndex = -1;
         _joinedMainPath = false;
         _reservedSlot = -1;
+        _crusherPathStep = 0;
+        _crusherSlotPos = {0.0f, 0.0f, 0.0f, 0.0f};
     }
 
     uint32 _currentWaypoint;
@@ -215,6 +223,8 @@ struct npc_hadronox_addAI : public ScriptedAI
     int32 _spawnIndex;
     bool _joinedMainPath;
     int32 _reservedSlot;
+    uint32 _crusherPathStep;
+    Position _crusherSlotPos;
     EventMap events;
 
     bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
@@ -245,6 +255,17 @@ struct npc_hadronox_addAI : public ScriptedAI
             _reservedSlot = (int32)value;
     }
 
+    void StartCrusherPath(const Position& slotPos)
+    {
+        _crusherSlotPos = slotPos;
+        _crusherPathStep = 1;
+        me->GetMotionMaster()->MovePoint(0,
+            addWaypoints[0].GetPositionX(),
+            addWaypoints[0].GetPositionY(),
+            addWaypoints[0].GetPositionZ(),
+            FORCED_MOVEMENT_RUN);
+    }
+
     void ReleaseSlot()
     {
         if (_reservedSlot >= 0 && _reservedSlot < 4)
@@ -270,6 +291,27 @@ struct npc_hadronox_addAI : public ScriptedAI
         _chasingHadronox = false;
         me->SetReactState(REACT_AGGRESSIVE);
         AttackStart(hadronox);
+        ScheduleCombatEvents();
+    }
+
+    void PullIntoCombat(Unit* puller)
+    {
+        if (_attackedByPlayer)
+            return;
+        _attackedByPlayer = true;
+        _reachedHadronox = false;
+        _chasingHadronox = false;
+        _crusherPathStep = 0;
+        me->GetMotionMaster()->Clear();
+        me->SetReactState(REACT_AGGRESSIVE);
+        if (puller)
+        {
+            if (Unit* victim = puller->GetVictim())
+            {
+                AttackStart(victim);
+                me->AddThreat(victim, 1.0f);
+            }
+        }
         ScheduleCombatEvents();
     }
 
@@ -330,11 +372,18 @@ struct npc_hadronox_addAI : public ScriptedAI
             _attackedByPlayer = true;
             _reachedHadronox = false;
             _chasingHadronox = false;
+            _crusherPathStep = 0;
             me->GetMotionMaster()->Clear();
             me->SetReactState(REACT_AGGRESSIVE);
             if (who->IsPlayer())
                 AttackStart(who);
             ScheduleCombatEvents();
+
+            std::list<Creature*> crushers;
+            me->GetCreaturesWithEntryInRange(crushers, 10.0f, NPC_ANUB_AR_CRUSHER);
+            for (Creature* crusher : crushers)
+                if (crusher->IsAlive() && !crusher->IsInCombat())
+                    crusher->AI()->AttackStart(who);
         }
     }
 
@@ -354,6 +403,44 @@ struct npc_hadronox_addAI : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
+        if (_crusherPathStep > 0 && !_attackedByPlayer)
+        {
+            if (_crusherPathStep == 1)
+            {
+                if (me->GetExactDist(addWaypoints[0]) <= WAYPOINT_REACH)
+                {
+                    _crusherPathStep = 2;
+                    me->GetMotionMaster()->MovePoint(1,
+                        _crusherSlotPos.GetPositionX(),
+                        _crusherSlotPos.GetPositionY(),
+                        _crusherSlotPos.GetPositionZ(),
+                        FORCED_MOVEMENT_RUN);
+                }
+                else if (!me->isMoving())
+                {
+                    me->GetMotionMaster()->MovePoint(0,
+                        addWaypoints[0].GetPositionX(),
+                        addWaypoints[0].GetPositionY(),
+                        addWaypoints[0].GetPositionZ(),
+                        FORCED_MOVEMENT_RUN);
+                }
+            }
+            else if (_crusherPathStep == 2)
+            {
+                if (me->GetExactDist(_crusherSlotPos) <= WAYPOINT_REACH)
+                    _crusherPathStep = 0;
+                else if (!me->isMoving())
+                {
+                    me->GetMotionMaster()->MovePoint(1,
+                        _crusherSlotPos.GetPositionX(),
+                        _crusherSlotPos.GetPositionY(),
+                        _crusherSlotPos.GetPositionZ(),
+                        FORCED_MOVEMENT_RUN);
+                }
+            }
+            return;
+        }
+
         if (_attackedByPlayer)
         {
             bool hasPlayerThreat = false;
@@ -926,7 +1013,7 @@ public:
             }
             return false;
         }
-        
+
         bool AnyPlayerInHadronoxUpperGauntlet() const
         {
             Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
@@ -1137,7 +1224,7 @@ public:
                                 StartSummonEvents();
                             }
                         }
-                        
+
                         if (AnyPlayerInHadronoxGauntlet())
                         {
                             if (!_walkStarted && AnyPlayerBelowWalkTrigger())
@@ -1263,44 +1350,105 @@ public:
 
         void ScheduleAddSpawns()
         {
-            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD1, 500ms);
-            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD2, 1000ms);
+            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD1, 250ms);
+            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD2, 500ms);
+            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD3, 750ms);
+            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD4, 1000ms);
         }
 
-        uint32 GetRandomAddEntry()
+        // Two slots in HadronoxAddSlots::Positions with the greatest distance between them
+        void GetFarthestSlotPair(int32& a, int32& b)
         {
-            uint32 roll = urand(0, 2);
-            return (roll == 0) ? NPC_ANUB_AR_CHAMPION : (roll == 1) ? NPC_ANUB_AR_NECROMANCER : NPC_ANUB_AR_CRYPTFIEND;
-        }
-
-        void SpawnAddAtSlot()
-        {
-            int32 bestIndex = -1;
-            float bestDist = FLT_MAX;
+            float bestDist = -1.0f;
+            a = 0;
+            b = 1;
             for (int i = 0; i < 4; ++i)
             {
-                if (HadronoxAddSlots::Occupied[i])
-                    continue;
-                float d = me->GetExactDist(HadronoxAddSlots::Positions[i]);
-                if (d < bestDist)
+                for (int j = i + 1; j < 4; ++j)
                 {
-                    bestDist = d;
-                    bestIndex = i;
+                    float d = HadronoxAddSlots::Positions[i].GetExactDist(HadronoxAddSlots::Positions[j]);
+                    if (d > bestDist)
+                    {
+                        bestDist = d;
+                        a = i;
+                        b = j;
+                    }
                 }
             }
+        }
 
-            if (bestIndex < 0)
+        // Two slots in HadronoxAddSlots::Positions with the smallest distance between them
+        void GetClosestSlotPair(int32& a, int32& b)
+        {
+            float bestDist = FLT_MAX;
+            a = 0;
+            b = 1;
+            for (int i = 0; i < 4; ++i)
+            {
+                for (int j = i + 1; j < 4; ++j)
+                {
+                    if (HadronoxAddSlots::Occupied[i] || HadronoxAddSlots::Occupied[j])
+                        continue;
+                    float d = HadronoxAddSlots::Positions[i].GetExactDist(HadronoxAddSlots::Positions[j]);
+                    if (d < bestDist)
+                    {
+                        bestDist = d;
+                        a = i;
+                        b = j;
+                    }
+                }
+            }
+        }
+
+        int32 PickUnoccupiedFromPair(int32 a, int32 b)
+        {
+            if (!HadronoxAddSlots::Occupied[a])
+                return a;
+            if (!HadronoxAddSlots::Occupied[b])
+                return b;
+            return -1;
+        }
+
+        void SpawnAddAt(uint32 spawnPointIndex, uint32 entry, int32 slotIndex)
+        {
+            if (slotIndex < 0)
                 return;
 
-            HadronoxAddSlots::Occupied[bestIndex] = true;
-            Creature* add = me->SummonCreature(GetRandomAddEntry(),
-                HadronoxAddSlots::Positions[bestIndex].GetPositionX(),
-                HadronoxAddSlots::Positions[bestIndex].GetPositionY(),
-                HadronoxAddSlots::Positions[bestIndex].GetPositionZ(),
+            const Position& spawnPos = addSpawnPos[spawnPointIndex];
+            HadronoxAddSlots::Occupied[slotIndex] = true;
+            Creature* add = me->SummonCreature(entry,
+                spawnPos.GetPositionX(), spawnPos.GetPositionY(), spawnPos.GetPositionZ(),
                 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 10000);
 
             if (add)
-                add->AI()->SetData(1, (uint32)bestIndex);
+            {
+                add->AI()->SetData(1, (uint32)slotIndex);
+                static_cast<npc_hadronox_addAI*>(add->AI())->StartCrusherPath(HadronoxAddSlots::Positions[slotIndex]);
+            }
+        }
+
+        void PullNearbyAdds()
+        {
+            std::list<Creature*> nearbyAdds;
+            for (uint32 entry : {(uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_NECROMANCER, (uint32)NPC_ANUB_AR_CRYPTFIEND})
+            {
+                std::list<Creature*> cl;
+                me->GetCreaturesWithEntryInRange(cl, 10.0f, entry);
+                nearbyAdds.merge(cl);
+            }
+            for (Creature* add : nearbyAdds)
+            {
+                if (!add->IsAlive())
+                    continue;
+                npc_hadronox_addAI* addAI = static_cast<npc_hadronox_addAI*>(add->AI());
+                if (!addAI || addAI->_attackedByPlayer)
+                    continue;
+                if (TempSummon* ts = add->ToTempSummon())
+                    if (Unit* summoner = ts->GetSummonerUnit())
+                        if (summoner->GetEntry() == NPC_HADRONOX && addAI->_spawnedAbove735)
+                            continue;
+                addAI->PullIntoCombat(me);
+            }
         }
 
         void JustEngagedWith(Unit*) override
@@ -1337,33 +1485,31 @@ public:
                     const Position& assignDest2 = (c1DistToDest1 <= c1DistToDest2) ? dest2 : dest1;
 
                     static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(assignDest1);
-                    static_cast<npc_anub_ar_crusherAI*>(c1->AI())->ScheduleAddSpawns();
-
                     static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(assignDest2);
-                    static_cast<npc_anub_ar_crusherAI*>(c2->AI())->ScheduleAddSpawns();
                 }
                 else
                 {
                     if (c1)
-                    {
                         static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(dest1);
-                        static_cast<npc_anub_ar_crusherAI*>(c1->AI())->ScheduleAddSpawns();
-                    }
                     if (c2)
-                    {
                         static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(dest2);
-                        static_cast<npc_anub_ar_crusherAI*>(c2->AI())->ScheduleAddSpawns();
-                    }
                 }
+
+                ScheduleAddSpawns();
             }
 
             events.ScheduleEvent(EVENT_CRUSHER_SMASH, 8s, 0, 0);
             events.ScheduleEvent(EVENT_CHECK_HEALTH, 1s);
+
+            PullNearbyAdds();
         }
 
         void EnterEvadeMode(EvadeReason /*why*/) override
         {
             summons.DespawnAll();
+            if (!_isSpawnedCrusher)
+                HadronoxAddSlots::Reset();
+
             if (!_isSpawnedCrusher)
             {
                 if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
@@ -1444,12 +1590,36 @@ public:
                     events.ScheduleEvent(EVENT_CHECK_HEALTH, 1s);
                     break;
                 case EVENT_CRUSHER_SPAWN_ADD1:
-                    if (_isSpawnedCrusher)
-                        SpawnAddAtSlot();
+                    if (!_isSpawnedCrusher)
+                    {
+                        int32 a, b;
+                        GetFarthestSlotPair(a, b);
+                        SpawnAddAt(0, NPC_ANUB_AR_CRYPTFIEND, PickUnoccupiedFromPair(a, b));
+                    }
                     break;
                 case EVENT_CRUSHER_SPAWN_ADD2:
-                    if (_isSpawnedCrusher)
-                        SpawnAddAtSlot();
+                    if (!_isSpawnedCrusher)
+                    {
+                        int32 a, b;
+                        GetFarthestSlotPair(a, b);
+                        SpawnAddAt(1, NPC_ANUB_AR_CRYPTFIEND, PickUnoccupiedFromPair(a, b));
+                    }
+                    break;
+                case EVENT_CRUSHER_SPAWN_ADD3:
+                    if (!_isSpawnedCrusher)
+                    {
+                        int32 a, b;
+                        GetClosestSlotPair(a, b);
+                        SpawnAddAt(0, NPC_ANUB_AR_NECROMANCER, PickUnoccupiedFromPair(a, b));
+                    }
+                    break;
+                case EVENT_CRUSHER_SPAWN_ADD4:
+                    if (!_isSpawnedCrusher)
+                    {
+                        int32 a, b;
+                        GetClosestSlotPair(a, b);
+                        SpawnAddAt(1, NPC_ANUB_AR_NECROMANCER, PickUnoccupiedFromPair(a, b));
+                    }
                     break;
             }
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1359,60 +1359,7 @@ public:
             events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD3, 750ms);
             events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD4, 1000ms);
         }
-
-        // Two slots in HadronoxAddSlots::Positions with the greatest distance between them
-        void GetFarthestSlotPair(int32& a, int32& b)
-        {
-            float bestDist = -1.0f;
-            a = 0;
-            b = 1;
-            for (int i = 0; i < 4; ++i)
-            {
-                for (int j = i + 1; j < 4; ++j)
-                {
-                    float d = HadronoxAddSlots::Positions[i].GetExactDist(HadronoxAddSlots::Positions[j]);
-                    if (d > bestDist)
-                    {
-                        bestDist = d;
-                        a = i;
-                        b = j;
-                    }
-                }
-            }
-        }
-
-        // Two slots in HadronoxAddSlots::Positions with the smallest distance between them
-        void GetClosestSlotPair(int32& a, int32& b)
-        {
-            float bestDist = FLT_MAX;
-            a = 0;
-            b = 1;
-            for (int i = 0; i < 4; ++i)
-            {
-                for (int j = i + 1; j < 4; ++j)
-                {
-                    if (HadronoxAddSlots::Occupied[i] || HadronoxAddSlots::Occupied[j])
-                        continue;
-                    float d = HadronoxAddSlots::Positions[i].GetExactDist(HadronoxAddSlots::Positions[j]);
-                    if (d < bestDist)
-                    {
-                        bestDist = d;
-                        a = i;
-                        b = j;
-                    }
-                }
-            }
-        }
-
-        int32 PickUnoccupiedFromPair(int32 a, int32 b)
-        {
-            if (!HadronoxAddSlots::Occupied[a])
-                return a;
-            if (!HadronoxAddSlots::Occupied[b])
-                return b;
-            return -1;
-        }
-
+        
         void SpawnAddAt(uint32 spawnPointIndex, uint32 entry, int32 slotIndex)
         {
             if (slotIndex < 0)
@@ -1595,35 +1542,19 @@ public:
                     break;
                 case EVENT_CRUSHER_SPAWN_ADD1:
                     if (!_isSpawnedCrusher)
-                    {
-                        int32 a, b;
-                        GetFarthestSlotPair(a, b);
-                        SpawnAddAt(0, NPC_ANUB_AR_CRYPTFIEND, PickUnoccupiedFromPair(a, b));
-                    }
+                        SpawnAddAt(0, NPC_ANUB_AR_CRYPTFIEND, 0);
                     break;
                 case EVENT_CRUSHER_SPAWN_ADD2:
                     if (!_isSpawnedCrusher)
-                    {
-                        int32 a, b;
-                        GetFarthestSlotPair(a, b);
-                        SpawnAddAt(1, NPC_ANUB_AR_CRYPTFIEND, PickUnoccupiedFromPair(a, b));
-                    }
+                        SpawnAddAt(1, NPC_ANUB_AR_CRYPTFIEND, 3);
                     break;
                 case EVENT_CRUSHER_SPAWN_ADD3:
                     if (!_isSpawnedCrusher)
-                    {
-                        int32 a, b;
-                        GetClosestSlotPair(a, b);
-                        SpawnAddAt(0, NPC_ANUB_AR_NECROMANCER, PickUnoccupiedFromPair(a, b));
-                    }
+                        SpawnAddAt(0, NPC_ANUB_AR_NECROMANCER, 1);
                     break;
                 case EVENT_CRUSHER_SPAWN_ADD4:
                     if (!_isSpawnedCrusher)
-                    {
-                        int32 a, b;
-                        GetClosestSlotPair(a, b);
-                        SpawnAddAt(1, NPC_ANUB_AR_NECROMANCER, PickUnoccupiedFromPair(a, b));
-                    }
+                        SpawnAddAt(1, NPC_ANUB_AR_NECROMANCER, 2);
                     break;
             }
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -743,8 +743,7 @@ public:
                 webDummyPositions[index].GetOrientation(),
                 TEMPSUMMON_MANUAL_DESPAWN))
             {
-                dummy->SetReactState(REACT_PASSIVE);
-                dummy->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
+                dummy->SetObjectScale(0.5f);
                 dummy->AddAura(SPELL_WEB_SIDE_DOORS, dummy);
             }
         }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -72,6 +72,8 @@ enum Events
 
     EVENT_CRUSHER_SMASH             = 20,
     EVENT_CHECK_HEALTH              = 21,
+    EVENT_CRUSHER_SPAWN_ADD1        = 22,
+    EVENT_CRUSHER_SPAWN_ADD2        = 23,
 
     EVENT_CHAMPION_REND             = 1,
     EVENT_CHAMPION_PUMMEL           = 2,
@@ -151,6 +153,24 @@ const Position addWaypoints[ADD_WAYPOINT_COUNT] =
 
 const Position ADD_SPAWN3_JOIN_WP = {609.41376f, 574.623f, 722.0532f, 0.0f};
 
+namespace HadronoxAddSlots
+{
+    static const Position Positions[4] =
+    {
+        {544.9088f,  567.09296f, 731.0783f,  0.0f},
+        {534.2329f,  561.84143f, 732.4554f,  0.0f},
+        {526.7353f,  560.04004f, 732.99493f, 0.0f},
+        {516.26666f, 566.3751f,  734.37054f, 0.0f}
+    };
+    static bool Occupied[4] = {false, false, false, false};
+
+    static void Reset()
+    {
+        for (int i = 0; i < 4; ++i)
+            Occupied[i] = false;
+    }
+}
+
 static bool IsValidSpellTarget(Unit* caster, WorldObject* target)
 {
     if (!caster || !target)
@@ -174,6 +194,7 @@ struct npc_hadronox_addAI : public ScriptedAI
         _checkTimer = 0;
         _spawnIndex = -1;
         _joinedMainPath = false;
+        _reservedSlot = -1;
     }
 
     uint32 _currentWaypoint;
@@ -184,6 +205,7 @@ struct npc_hadronox_addAI : public ScriptedAI
     uint32 _checkTimer;
     int32 _spawnIndex;
     bool _joinedMainPath;
+    int32 _reservedSlot;
     EventMap events;
 
     bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
@@ -203,9 +225,23 @@ struct npc_hadronox_addAI : public ScriptedAI
 
     void SetData(uint32 /*id*/, uint32 value) override
     {
-        _spawnIndex = (int32)value;
-        _spawnedAbove735 = true;
-        IssueMove();
+        if (id == 0)
+        {
+            _spawnIndex = (int32)value;
+            _spawnedAbove735 = true;
+            IssueMove();
+        }
+        else if (id == 1)
+            _reservedSlot = (int32)value;
+    }
+
+    void ReleaseSlot()
+    {
+        if (_reservedSlot >= 0 && _reservedSlot < 4)
+        {
+            HadronoxAddSlots::Occupied[_reservedSlot] = false;
+            _reservedSlot = -1;
+        }
     }
 
     Creature* FindHadronox() const
@@ -426,6 +462,7 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
+            ReleaseSlot();
             me->DespawnOrUnsummon(10000ms);
         }
 
@@ -494,6 +531,7 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
+            ReleaseSlot();
             me->DespawnOrUnsummon(10000ms);
         }
 
@@ -562,6 +600,7 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
+            ReleaseSlot();
             me->DespawnOrUnsummon(10000ms);
         }
 
@@ -649,6 +688,7 @@ public:
         void Reset() override
         {
             BossAI::Reset();
+            HadronoxAddSlots::Reset();
             _walkStarted = false;
             _spawnsActive = true;
             _combatStarted = false;
@@ -1114,6 +1154,48 @@ public:
                 FORCED_MOVEMENT_RUN);
         }
 
+        void ScheduleAddSpawns()
+        {
+            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD1, 500ms);
+            events.ScheduleEvent(EVENT_CRUSHER_SPAWN_ADD2, 1000ms);
+        }
+
+        uint32 GetRandomAddEntry()
+        {
+            uint32 roll = urand(0, 2);
+            return (roll == 0) ? NPC_ANUB_AR_CHAMPION : (roll == 1) ? NPC_ANUB_AR_NECROMANCER : NPC_ANUB_AR_CRYPTFIEND;
+        }
+
+        void SpawnAddAtSlot()
+        {
+            int32 bestIndex = -1;
+            float bestDist = FLT_MAX;
+            for (int i = 0; i < 4; ++i)
+            {
+                if (HadronoxAddSlots::Occupied[i])
+                    continue;
+                float d = me->GetExactDist(HadronoxAddSlots::Positions[i]);
+                if (d < bestDist)
+                {
+                    bestDist = d;
+                    bestIndex = i;
+                }
+            }
+
+            if (bestIndex < 0)
+                return;
+
+            HadronoxAddSlots::Occupied[bestIndex] = true;
+            Creature* add = me->SummonCreature(GetRandomAddEntry(),
+                HadronoxAddSlots::Positions[bestIndex].GetPositionX(),
+                HadronoxAddSlots::Positions[bestIndex].GetPositionY(),
+                HadronoxAddSlots::Positions[bestIndex].GetPositionZ(),
+                0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 10000);
+
+            if (add)
+                add->AI()->SetData(1, (uint32)bestIndex);
+        }
+
         void JustEngagedWith(Unit*) override
         {
             if (!_isSpawnedCrusher)
@@ -1147,9 +1229,11 @@ public:
 
                     c1->AI()->SetData(0, 0);
                     static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(assignDest1);
+                    static_cast<npc_anub_ar_crusherAI*>(c1->AI())->ScheduleAddSpawns();
 
                     c2->AI()->SetData(0, 0);
                     static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(assignDest2);
+                    static_cast<npc_anub_ar_crusherAI*>(c2->AI())->ScheduleAddSpawns();
                 }
                 else
                 {
@@ -1157,11 +1241,13 @@ public:
                     {
                         c1->AI()->SetData(0, 0);
                         static_cast<npc_anub_ar_crusherAI*>(c1->AI())->SetDestination(dest1);
+                        static_cast<npc_anub_ar_crusherAI*>(c1->AI())->ScheduleAddSpawns();
                     }
                     if (c2)
                     {
                         c2->AI()->SetData(0, 0);
                         static_cast<npc_anub_ar_crusherAI*>(c2->AI())->SetDestination(dest2);
+                        static_cast<npc_anub_ar_crusherAI*>(c2->AI())->ScheduleAddSpawns();
                     }
                 }
             }
@@ -1250,6 +1336,14 @@ public:
                         break;
                     }
                     events.ScheduleEvent(EVENT_CHECK_HEALTH, 1s);
+                    break;
+                case EVENT_CRUSHER_SPAWN_ADD1:
+                    if (_isSpawnedCrusher)
+                        SpawnAddAtSlot();
+                    break;
+                case EVENT_CRUSHER_SPAWN_ADD2:
+                    if (_isSpawnedCrusher)
+                        SpawnAddAtSlot();
                     break;
             }
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -1176,6 +1176,8 @@ public:
                 if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
                     hadronox->AI()->DoAction(ACTION_CRUSHER_EVADE);
             }
+            else
+                me->DespawnOrUnsummon();
 
             ScriptedAI::EnterEvadeMode();
         }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -96,8 +96,10 @@ constexpr float GAUNTLET_END_Z     = 640.0f;
 constexpr float GAUNTLET_START_Z   = 730.0f;
 constexpr float STEP_REACH         = 3.0f;
 constexpr float STEP_SPEED         = 5.0f;
-constexpr float ADDS_RANGE         = 5.0f;
-const Position HADRONOX_SPAWN_POS  = {522.531f, 544.911f, 647.679f, 0.0f};
+constexpr float ADDS_RANGE         = 8.0f;
+constexpr float SPELL_MAX_DIST     = 40.0f;
+constexpr float SPELL_MAX_Z_DIFF   = 20.0f;
+const Position HADRONOX_SPAWN_POS  = {522.531f, 544.911f, 674.679f, 0.0f};
 
 // Indices 0-3: start waypoints (approach phase), indices 4-7: combat steps
 const Position hadronoxWaypoints[8] =
@@ -129,6 +131,17 @@ const Position addWaypoints[8] =
     {559.21f, 512.35f, 695.00f, 0.0f},
     {522.53f, 544.91f, 674.68f, 0.0f}
 };
+
+static bool IsValidSpellTarget(Unit* caster, WorldObject* target)
+{
+    if (!caster || !target)
+        return false;
+    if (caster->GetExactDist(target) > SPELL_MAX_DIST)
+        return false;
+    if (std::abs(caster->GetPositionZ() - target->GetPositionZ()) > SPELL_MAX_Z_DIFF)
+        return false;
+    return true;
+}
 
 struct npc_hadronox_addAI : public ScriptedAI
 {
@@ -262,14 +275,20 @@ public:
         {
             UpdateWalk(diff);
 
+            if (_spawnedAbove745 && !ShouldUseCombatAbilities())
+                me->SetReactState(REACT_PASSIVE);
+            else if (me->GetReactState() == REACT_PASSIVE)
+            {
+                me->SetReactState(REACT_AGGRESSIVE);
+                if (me->GetVictim())
+                    AttackStart(me->GetVictim());
+            }
+
             if (!UpdateVictim())
                 return;
 
             if (!ShouldUseCombatAbilities())
-            {
-                DoMeleeAttackIfReady();
                 return;
-            }
 
             events.Update(diff);
 
@@ -279,11 +298,12 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_CHAMPION_REND:
-                    me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_CHAMPION_REND_H : SPELL_CHAMPION_REND, false);
+                    if (me->GetVictim() && IsValidSpellTarget(me, me->GetVictim()))
+                        me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_CHAMPION_REND_H : SPELL_CHAMPION_REND, false);
                     events.ScheduleEvent(EVENT_CHAMPION_REND, Milliseconds(urand(12000, 18000)));
                     break;
                 case EVENT_CHAMPION_PUMMEL:
-                    if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+                    if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING) && IsValidSpellTarget(me, me->GetVictim()))
                         me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_CHAMPION_PUMMEL_H : SPELL_CHAMPION_PUMMEL, false);
                     events.ScheduleEvent(EVENT_CHAMPION_PUMMEL, Milliseconds(urand(9000, 13000)));
                     break;
@@ -323,14 +343,20 @@ public:
         {
             UpdateWalk(diff);
 
+            if (_spawnedAbove745 && !ShouldUseCombatAbilities())
+                me->SetReactState(REACT_PASSIVE);
+            else if (me->GetReactState() == REACT_PASSIVE)
+            {
+                me->SetReactState(REACT_AGGRESSIVE);
+                if (me->GetVictim())
+                    AttackStart(me->GetVictim());
+            }
+
             if (!UpdateVictim())
                 return;
 
             if (!ShouldUseCombatAbilities())
-            {
-                DoMeleeAttackIfReady();
                 return;
-            }
 
             events.Update(diff);
 
@@ -340,12 +366,14 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_NECRO_INFECTED_WOUND:
-                    me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_NECROMANCER_INFECTED_WOUND_H : SPELL_NECROMANCER_INFECTED_WOUND, false);
+                    if (me->GetVictim() && IsValidSpellTarget(me, me->GetVictim()))
+                        me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_NECROMANCER_INFECTED_WOUND_H : SPELL_NECROMANCER_INFECTED_WOUND, false);
                     events.ScheduleEvent(EVENT_NECRO_INFECTED_WOUND, Milliseconds(urand(9000, 12000)));
                     break;
                 case EVENT_NECRO_CRUSHING_WEBS:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 30.0f, true))
-                        me->CastSpell(target, IsHeroic() ? SPELL_NECROMANCER_CRUSHING_WEBS_H : SPELL_NECROMANCER_CRUSHING_WEBS, false);
+                        if (IsValidSpellTarget(me, target))
+                            me->CastSpell(target, IsHeroic() ? SPELL_NECROMANCER_CRUSHING_WEBS_H : SPELL_NECROMANCER_CRUSHING_WEBS, false);
                     events.ScheduleEvent(EVENT_NECRO_CRUSHING_WEBS, Milliseconds(urand(10000, 13000)));
                     break;
             }
@@ -383,14 +411,20 @@ public:
         {
             UpdateWalk(diff);
 
+            if (_spawnedAbove745 && !ShouldUseCombatAbilities())
+                me->SetReactState(REACT_PASSIVE);
+            else if (me->GetReactState() == REACT_PASSIVE)
+            {
+                me->SetReactState(REACT_AGGRESSIVE);
+                if (me->GetVictim())
+                    AttackStart(me->GetVictim());
+            }
+
             if (!UpdateVictim())
                 return;
 
             if (!ShouldUseCombatAbilities())
-            {
-                DoMeleeAttackIfReady();
                 return;
-            }
 
             events.Update(diff);
 
@@ -400,7 +434,8 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_CRYPT_SHADOW_BOLT:
-                    me->CastSpell(me->GetVictim(), SPELL_CRYPT_FIEND_SHADOW_BOLT, true);
+                    if (me->GetVictim() && IsValidSpellTarget(me, me->GetVictim()))
+                        me->CastSpell(me->GetVictim(), SPELL_CRYPT_FIEND_SHADOW_BOLT, true);
                     events.ScheduleEvent(EVENT_CRYPT_SHADOW_BOLT, Milliseconds(urand(2000, 3000)));
                     break;
             }
@@ -665,12 +700,12 @@ public:
                         _lastPos = me->GetPosition();
                     }
                 }
-                
+
                 if (!_walkStarted)
                 {
                     if (me->GetExactDist(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ()) > 2.0f)
-                        me->GetMotionMaster()->MoveCharge(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ(), STEP_SPEED, 0, nullptr, true);
-
+                        me->GetMotionMaster()->MovePoint(0, HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ(), FORCED_MOVEMENT_NONE, 0.f, 0.f, false);
+                    
                     std::list<Creature*> addList;
                     for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
                     {
@@ -724,18 +759,21 @@ public:
                     break;
                 case EVENT_HADRONOX_PIERCE:
                     if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
-                        me->CastSpell(me->GetVictim(), SPELL_PIERCE_ARMOR, false);
+                        if (me->GetVictim() && IsValidSpellTarget(me, me->GetVictim()))
+                            me->CastSpell(me->GetVictim(), SPELL_PIERCE_ARMOR, false);
                     events.ScheduleEvent(EVENT_HADRONOX_PIERCE, 8s);
                     break;
                 case EVENT_HADRONOX_ACID:
                     if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100, false))
-                            me->CastSpell(target, SPELL_ACID_CLOUD, false);
+                            if (IsValidSpellTarget(me, target))
+                                me->CastSpell(target, SPELL_ACID_CLOUD, false);
                     events.ScheduleEvent(EVENT_HADRONOX_ACID, 25s);
                     break;
                 case EVENT_HADRONOX_LEECH:
                     if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
-                        me->CastSpell(me, SPELL_LEECH_POISON, false);
+                        if (IsValidSpellTarget(me, me->GetVictim()))
+                            me->CastSpell(me, SPELL_LEECH_POISON, false);
                     events.ScheduleEvent(EVENT_HADRONOX_LEECH, 12s);
                     break;
                 case EVENT_HADRONOX_GRAB:
@@ -825,7 +863,8 @@ public:
             switch (events.ExecuteEvent())
             {
                 case EVENT_CRUSHER_SMASH:
-                    me->CastSpell(me->GetVictim(), SPELL_SMASH, false);
+                    if (me->GetVictim() && IsValidSpellTarget(me, me->GetVictim()))
+                        me->CastSpell(me->GetVictim(), SPELL_SMASH, false);
                     events.ScheduleEvent(EVENT_CRUSHER_SMASH, 15s);
                     break;
                 case EVENT_CHECK_HEALTH:
@@ -896,9 +935,9 @@ class spell_hadronox_web_grab : public SpellScript
         Unit* caster = GetCaster();
         targets.remove_if([caster](WorldObject* target) -> bool
         {
-            if (caster->GetExactDist(target) > 40.0f)
+            if (caster->GetExactDist(target) > SPELL_MAX_DIST)
                 return true;
-            if (std::abs(caster->GetPositionZ() - target->GetPositionZ()) > 20.0f)
+            if (std::abs(caster->GetPositionZ() - target->GetPositionZ()) > SPELL_MAX_Z_DIFF)
                 return true;
             return false;
         });
@@ -906,7 +945,7 @@ class spell_hadronox_web_grab : public SpellScript
 
     void Register() override
     {
-        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hadronox_web_grab::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hadronox_web_grab::FilterTargets, EFFECT_ALL, TARGET_UNIT_SRC_AREA_ENEMY);
     }
 };
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -785,11 +785,6 @@ public:
             events.ScheduleEvent(EVENT_HADRONOX_SUMMON_ADD, 2s);
         }
 
-        Position GetNextSpawnPos()
-        {
-            return addSpawnPos[_spawnCount % 3];
-        }
-
         void SummonAdd(uint32 entry)
         {
             if (!_spawnsActive)

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -392,9 +392,7 @@ struct npc_hadronox_addAI : public ScriptedAI
             if (crusher->IsAlive() && !crusher->IsInCombat())
                 crusher->AI()->AttackStart(who);
     }
-
-    void JustEngagedWith(Unit* /*who*/) override {}
-
+    
     virtual void ScheduleCombatEvents() = 0;
 
     bool NearHadronox() const

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -38,23 +38,43 @@ enum Spells
     SPELL_PIERCE_ARMOR                      = 53418,
 
     SPELL_SMASH                             = 53318,
-    SPELL_FRENZY                            = 53801
+    SPELL_FRENZY                            = 53801,
+
+    SPELL_CHAMPION_REND                     = 53317,
+    SPELL_CHAMPION_REND_H                   = 59343,
+    SPELL_CHAMPION_PUMMEL                   = 53394,
+    SPELL_CHAMPION_PUMMEL_H                 = 59344,
+
+    SPELL_NECROMANCER_INFECTED_WOUND        = 53330,
+    SPELL_NECROMANCER_INFECTED_WOUND_H      = 59348,
+    SPELL_NECROMANCER_CRUSHING_WEBS         = 53322,
+    SPELL_NECROMANCER_CRUSHING_WEBS_H       = 59347,
+
+    SPELL_CRYPT_FIEND_SHADOW_BOLT           = 53333
 };
 
 enum Events
 {
-    EVENT_HADRONOX_MOVE1        = 1,
-    EVENT_HADRONOX_MOVE2        = 2,
-    EVENT_HADRONOX_MOVE3        = 3,
-    EVENT_HADRONOX_MOVE4        = 4,
-    EVENT_HADRONOX_ACID         = 5,
-    EVENT_HADRONOX_LEECH        = 6,
-    EVENT_HADRONOX_PIERCE       = 7,
-    EVENT_HADRONOX_GRAB         = 8,
-    EVENT_HADRONOX_SUMMON       = 9,
+    EVENT_HADRONOX_ACID             = 5,
+    EVENT_HADRONOX_LEECH            = 6,
+    EVENT_HADRONOX_PIERCE           = 7,
+    EVENT_HADRONOX_GRAB             = 8,
+    EVENT_HADRONOX_CHECK            = 10,
+    EVENT_HADRONOX_SUMMON_CHAMPION  = 11,
+    EVENT_HADRONOX_SUMMON_NECRO     = 12,
+    EVENT_HADRONOX_SUMMON_CRYPT     = 13,
+    EVENT_HADRONOX_STEP             = 14,
 
-    EVENT_CRUSHER_SMASH         = 20,
-    EVENT_CHECK_HEALTH          = 21
+    EVENT_CRUSHER_SMASH             = 20,
+    EVENT_CHECK_HEALTH              = 21,
+
+    EVENT_CHAMPION_REND             = 1,
+    EVENT_CHAMPION_PUMMEL           = 2,
+
+    EVENT_NECRO_INFECTED_WOUND      = 1,
+    EVENT_NECRO_CRUSHING_WEBS       = 2,
+
+    EVENT_CRYPT_SHADOW_BOLT         = 1
 };
 
 enum Misc
@@ -65,16 +85,334 @@ enum Misc
     SAY_CRUSHER_EMOTE           = 1,
     SAY_HADRONOX_EMOTE          = 0,
 
-    ACTION_DESPAWN_ADDS         = 1,
-    ACTION_START_EVENT          = 2
+    // ACTION_DESPAWN_ADDS         = 1,
+    ACTION_START_EVENT          = 2,
+    ACTION_START_WALK           = 3,
+    ACTION_STOP_SPAWNS          = 4,
+    ACTION_CRUSHER_EVADE        = 5
 };
 
-const Position hadronoxSteps[4] =
+constexpr float GAUNTLET_END_Z     = 640.0f;
+constexpr float GAUNTLET_START_Z   = 730.0f;
+constexpr float STEP_REACH         = 3.0f;
+constexpr float STEP_SPEED         = 5.0f;
+constexpr float ADDS_RANGE         = 5.0f;
+const Position HADRONOX_SPAWN_POS  = {522.531f, 544.911f, 647.679f, 0.0f};
+
+// Indices 0-3: start waypoints (approach phase), indices 4-7: combat steps
+const Position hadronoxWaypoints[8] =
 {
-    {607.9f, 512.8f, 695.3f, 0.0f},
-    {611.67f, 564.11f, 720.0f, 0.0f},
-    {576.1f, 580.0f, 727.5f, 0.0f},
-    {534.87f, 554.0f, 733.0f, 0.0f}
+    {533.5879f,  533.34607f, 681.70135f, 0.0f},
+    {530.96313f, 520.79193f, 688.7247f,  0.0f},
+    {533.6001f,  514.1237f,  694.8442f,  0.0f},
+    {567.3953f,  513.29114f, 698.8085f,  0.0f},
+    {607.9f,     512.8f,     695.3f,     0.0f},
+    {611.67f,    564.11f,    720.0f,     0.0f},
+    {576.1f,     580.0f,     727.5f,     0.0f},
+    {534.87f,    554.0f,     733.0f,     0.0f}
+};
+
+const Position addSpawnPos[2] =
+{
+    {577.2f, 613.45f, 771.51f, 0.0f},
+    {483.68f, 612.75f, 771.42f, 0.0f}
+};
+
+const Position addWaypoints[8] =
+{
+    {531.00f, 573.00f, 733.00f, 0.0f},
+    {546.76f, 563.00f, 730.87f, 0.0f},
+    {585.83f, 577.74f, 726.00f, 0.0f},
+    {610.95f, 565.35f, 719.56f, 0.0f},
+    {620.81f, 531.21f, 700.74f, 0.0f},
+    {604.28f, 510.95f, 694.65f, 0.0f},
+    {559.21f, 512.35f, 695.00f, 0.0f},
+    {522.53f, 544.91f, 674.68f, 0.0f}
+};
+
+struct npc_hadronox_addAI : public ScriptedAI
+{
+    npc_hadronox_addAI(Creature* creature) : ScriptedAI(creature)
+    {
+        _currentWaypoint = 0;
+        _reachedHadronox = false;
+        _attackedByPlayer = false;
+        _spawnedAbove745 = creature->GetPositionZ() >= 745.0f;
+        _lastPos = creature->GetPosition();
+    }
+
+    uint32 _currentWaypoint;
+    bool _reachedHadronox;
+    bool _attackedByPlayer;
+    bool _spawnedAbove745;
+    Position _lastPos;
+    EventMap events;
+
+    bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
+
+    void Reset() override
+    {
+        _currentWaypoint = 0;
+        _reachedHadronox = false;
+        _attackedByPlayer = false;
+        _lastPos = me->GetPosition();
+        events.Reset();
+        if (_spawnedAbove745)
+            MoveToNextWaypoint();
+    }
+
+    void MoveToNextWaypoint()
+    {
+        if (_currentWaypoint >= 8)
+            return;
+        me->GetMotionMaster()->MovePoint(_currentWaypoint, addWaypoints[_currentWaypoint]);
+    }
+
+    void MovementInform(uint32 type, uint32 id) override
+    {
+        if (type != POINT_MOTION_TYPE || _reachedHadronox || _attackedByPlayer)
+            return;
+
+        _currentWaypoint = id + 1;
+        if (_currentWaypoint < 8)
+            MoveToNextWaypoint();
+    }
+
+    void DamageTaken(Unit* who, uint32& /*damage*/, DamageEffectType /*damageType*/, SpellSchoolMask /*damageSchoolMask*/) override
+    {
+        if (!_attackedByPlayer && who && who->IsControlledByPlayer())
+        {
+            _attackedByPlayer = true;
+            _reachedHadronox = false;
+            me->GetMotionMaster()->Clear();
+            if (who->IsPlayer())
+                AttackStart(who);
+            ScheduleCombatEvents();
+        }
+    }
+
+    void JustEngagedWith(Unit* /*who*/) override
+    {
+    }
+
+    virtual void ScheduleCombatEvents() = 0;
+
+    bool NearHadronox() const
+    {
+        if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, ADDS_RANGE, true))
+            return true;
+        return false;
+    }
+
+    void UpdateWalk(uint32 /*diff*/)
+    {
+        if (_reachedHadronox || _attackedByPlayer)
+            return;
+
+        if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+        {
+            float zDiff = std::abs(me->GetPositionZ() - hadronox->GetPositionZ());
+            if (zDiff <= ADDS_RANGE)
+            {
+                _reachedHadronox = true;
+                me->GetMotionMaster()->Clear();
+                me->GetMotionMaster()->MoveChase(hadronox);
+                AttackStart(hadronox);
+                ScheduleCombatEvents();
+                return;
+            }
+        }
+
+        if (_spawnedAbove745)
+        {
+            float movedDist = me->GetExactDist(_lastPos.GetPositionX(), _lastPos.GetPositionY(), _lastPos.GetPositionZ());
+            if (movedDist < 0.1f && _currentWaypoint < 8)
+                MoveToNextWaypoint();
+            _lastPos = me->GetPosition();
+        }
+    }
+
+    bool ShouldUseCombatAbilities() const
+    {
+        return _attackedByPlayer || NearHadronox();
+    }
+};
+
+class npc_anub_ar_champion : public CreatureScript
+{
+public:
+    npc_anub_ar_champion() : CreatureScript("npc_anub_ar_champion") { }
+
+    struct npc_anub_ar_championAI : public npc_hadronox_addAI
+    {
+        npc_anub_ar_championAI(Creature* creature) : npc_hadronox_addAI(creature) { }
+
+        void ScheduleCombatEvents() override
+        {
+            events.ScheduleEvent(EVENT_CHAMPION_REND, Milliseconds(urand(4000, 7000)));
+            events.ScheduleEvent(EVENT_CHAMPION_PUMMEL, Milliseconds(urand(9000, 13000)));
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            me->DespawnOrUnsummon(10000ms);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            UpdateWalk(diff);
+
+            if (!UpdateVictim())
+                return;
+
+            if (!ShouldUseCombatAbilities())
+            {
+                DoMeleeAttackIfReady();
+                return;
+            }
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            switch (events.ExecuteEvent())
+            {
+                case EVENT_CHAMPION_REND:
+                    me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_CHAMPION_REND_H : SPELL_CHAMPION_REND, false);
+                    events.ScheduleEvent(EVENT_CHAMPION_REND, Milliseconds(urand(12000, 18000)));
+                    break;
+                case EVENT_CHAMPION_PUMMEL:
+                    if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+                        me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_CHAMPION_PUMMEL_H : SPELL_CHAMPION_PUMMEL, false);
+                    events.ScheduleEvent(EVENT_CHAMPION_PUMMEL, Milliseconds(urand(9000, 13000)));
+                    break;
+            }
+
+            DoMeleeAttackIfReady();
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetAzjolNerubAI<npc_anub_ar_championAI>(creature);
+    }
+};
+
+class npc_anub_ar_necromancer : public CreatureScript
+{
+public:
+    npc_anub_ar_necromancer() : CreatureScript("npc_anub_ar_necromancer") { }
+
+    struct npc_anub_ar_necromancerAI : public npc_hadronox_addAI
+    {
+        npc_anub_ar_necromancerAI(Creature* creature) : npc_hadronox_addAI(creature) { }
+
+        void ScheduleCombatEvents() override
+        {
+            events.ScheduleEvent(EVENT_NECRO_INFECTED_WOUND, Milliseconds(urand(4000, 7000)));
+            events.ScheduleEvent(EVENT_NECRO_CRUSHING_WEBS, Milliseconds(urand(9000, 12000)));
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            me->DespawnOrUnsummon(10000ms);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            UpdateWalk(diff);
+
+            if (!UpdateVictim())
+                return;
+
+            if (!ShouldUseCombatAbilities())
+            {
+                DoMeleeAttackIfReady();
+                return;
+            }
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            switch (events.ExecuteEvent())
+            {
+                case EVENT_NECRO_INFECTED_WOUND:
+                    me->CastSpell(me->GetVictim(), IsHeroic() ? SPELL_NECROMANCER_INFECTED_WOUND_H : SPELL_NECROMANCER_INFECTED_WOUND, false);
+                    events.ScheduleEvent(EVENT_NECRO_INFECTED_WOUND, Milliseconds(urand(9000, 12000)));
+                    break;
+                case EVENT_NECRO_CRUSHING_WEBS:
+                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 30.0f, true))
+                        me->CastSpell(target, IsHeroic() ? SPELL_NECROMANCER_CRUSHING_WEBS_H : SPELL_NECROMANCER_CRUSHING_WEBS, false);
+                    events.ScheduleEvent(EVENT_NECRO_CRUSHING_WEBS, Milliseconds(urand(10000, 13000)));
+                    break;
+            }
+
+            DoMeleeAttackIfReady();
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetAzjolNerubAI<npc_anub_ar_necromancerAI>(creature);
+    }
+};
+
+class npc_anub_ar_cryptfiend : public CreatureScript
+{
+public:
+    npc_anub_ar_cryptfiend() : CreatureScript("npc_anub_ar_cryptfiend") { }
+
+    struct npc_anub_ar_cryptfiendAI : public npc_hadronox_addAI
+    {
+        npc_anub_ar_cryptfiendAI(Creature* creature) : npc_hadronox_addAI(creature) { }
+
+        void ScheduleCombatEvents() override
+        {
+            events.ScheduleEvent(EVENT_CRYPT_SHADOW_BOLT, Milliseconds(urand(0, 1000)));
+        }
+
+        void JustDied(Unit* /*killer*/) override
+        {
+            me->DespawnOrUnsummon(10000ms);
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            UpdateWalk(diff);
+
+            if (!UpdateVictim())
+                return;
+
+            if (!ShouldUseCombatAbilities())
+            {
+                DoMeleeAttackIfReady();
+                return;
+            }
+
+            events.Update(diff);
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+
+            switch (events.ExecuteEvent())
+            {
+                case EVENT_CRYPT_SHADOW_BOLT:
+                    me->CastSpell(me->GetVictim(), SPELL_CRYPT_FIEND_SHADOW_BOLT, true);
+                    events.ScheduleEvent(EVENT_CRYPT_SHADOW_BOLT, Milliseconds(urand(2000, 3000)));
+                    break;
+            }
+
+            DoMeleeAttackIfReady();
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetAzjolNerubAI<npc_anub_ar_cryptfiendAI>(creature);
+    }
 };
 
 class boss_hadronox : public CreatureScript
@@ -86,46 +424,110 @@ public:
     {
         boss_hadronoxAI(Creature* creature) : BossAI(creature, DATA_HADRONOX)
         {
+            _walkStarted = false;
+            _spawnsActive = true;
+            _combatStarted = false;
+            _playerAttacked = false;
+            _crusherAggroSaid = false;
+            _currentStep = -1;
+            _spawnCount = 0;
+            _movementCheckTimer = 0;
+            _lastPos = creature->GetPosition();
         }
+
+        bool _walkStarted;
+        bool _spawnsActive;
+        bool _combatStarted;
+        bool _playerAttacked;
+        bool _crusherAggroSaid;
+        int32 _currentStep;
+        uint32 _spawnCount;
+        uint32 _movementCheckTimer;
+        Position _lastPos;
 
         void Reset() override
         {
-            summons.DoAction(ACTION_DESPAWN_ADDS);
             BossAI::Reset();
-            me->SummonCreature(NPC_ANUB_AR_CRUSHER, 542.9f, 519.5f, 741.24f, 2.14f);
+            _walkStarted = false;
+            _spawnsActive = true;
+            _combatStarted = false;
+            _playerAttacked = false;
+            _crusherAggroSaid = false;
+            _currentStep = -1;
+            _spawnCount = 0;
+            _movementCheckTimer = 0;
+            _lastPos = me->GetPosition();
+            me->SummonCreature(NPC_ANUB_AR_CRUSHER, 531.5281f, 553.8509f, 732.56f, 5.053f);
+            me->SummonCreature(NPC_ANUB_AR_CRYPTFIEND, 524.07886f, 550.6797f, 731.873f, 5.053f);
+            me->SummonCreature(NPC_ANUB_AR_CHAMPION, 541.0999f, 555.21924f, 732.152f, 5.053f);
+            events.ScheduleEvent(EVENT_HADRONOX_CHECK, 1s);
+        }
+
+        void MoveToWaypoint(int32 index)
+        {
+            if (index < 0 || index >= 8)
+                return;
+            if (index == 6)
+                me->CastSpell(me, SPELL_WEB_FRONT_DOORS, true);
+            me->GetMotionMaster()->MoveCharge(
+                hadronoxWaypoints[index].GetPositionX(),
+                hadronoxWaypoints[index].GetPositionY(),
+                hadronoxWaypoints[index].GetPositionZ(),
+                STEP_SPEED, 0, nullptr, true);
+            _lastPos = me->GetPosition();
+        }
+
+        void StartWalkEvent()
+        {
+            if (_walkStarted)
+                return;
+            _walkStarted = true;
+            instance->SetBossState(DATA_HADRONOX, IN_PROGRESS);
+            me->setActive(true);
+            events.ScheduleEvent(EVENT_HADRONOX_STEP, 10s);
+        }
+
+        void StartSummonEvents()
+        {
+            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CHAMPION, 15s);
+            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_NECRO, 10s);
+            events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CRYPT, 5s);
+        }
+
+        Position GetNextSpawnPos()
+        {
+            return addSpawnPos[_spawnCount % 2];
+        }
+
+        void SummonAdd(uint32 entry)
+        {
+            if (!_spawnsActive)
+                return;
+            Position pos = GetNextSpawnPos();
+            me->SummonCreature(entry, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
+            _spawnCount++;
         }
 
         void DoAction(int32 param) override
         {
-            if (param == ACTION_START_EVENT)
-            {
-                instance->SetBossState(DATA_HADRONOX, IN_PROGRESS);
-                me->setActive(true);
-                events.ScheduleEvent(EVENT_HADRONOX_MOVE1, 20s);
-                events.ScheduleEvent(EVENT_HADRONOX_MOVE2, 40s);
-                events.ScheduleEvent(EVENT_HADRONOX_MOVE3, 60s);
-                events.ScheduleEvent(EVENT_HADRONOX_MOVE4, 80s);
-            }
+            if (param == ACTION_START_EVENT || param == ACTION_START_WALK)
+                StartWalkEvent();
+            else if (param == ACTION_STOP_SPAWNS)
+                _spawnsActive = false;
+            else if (param == ACTION_CRUSHER_EVADE)
+                me->AI()->EnterEvadeMode();
         }
 
         uint32 GetData(uint32 data) const override
         {
             if (data == me->GetEntry())
-                return !me->isActiveObject() || events.HasTimeUntilEvent(EVENT_HADRONOX_MOVE4) ? 1 : 0;
+                return (_currentStep < 7) ? 1 : 0;
             return 0;
         }
 
         void JustSummoned(Creature* summon) override
         {
             summons.Summon(summon);
-
-            // Xinef: cannot use pathfinding...
-            if (summon->GetDistance(477.0f, 618.0f, 771.0f) < 5.0f)
-                summon->GetMotionMaster()->MovePath(3000012, false);
-            else if (summon->GetDistance(583.0f, 617.0f, 771.0f) < 5.0f)
-                summon->GetMotionMaster()->MovePath(3000013, false);
-            else if (summon->GetDistance(581.0f, 608.5f, 739.0f) < 5.0f)
-                summon->GetMotionMaster()->MovePath(3000014, false);
         }
 
         void KilledUnit(Unit* victim) override
@@ -143,75 +545,208 @@ public:
 
         void JustEngagedWith(Unit*) override
         {
+            _combatStarted = true;
             events.RescheduleEvent(EVENT_HADRONOX_ACID, 10s);
             events.RescheduleEvent(EVENT_HADRONOX_LEECH, 4s);
             events.RescheduleEvent(EVENT_HADRONOX_PIERCE, 1s);
             events.RescheduleEvent(EVENT_HADRONOX_GRAB, 15s);
         }
 
+        void DamageTaken(Unit* who, uint32& damage, DamageEffectType /*damageType*/, SpellSchoolMask /*damageSchoolMask*/) override
+        {
+            if (who && who->IsControlledByPlayer() && !_playerAttacked)
+            {
+                _playerAttacked = true;
+                _spawnsActive = false;
+                events.CancelEvent(EVENT_HADRONOX_STEP);
+                me->GetMotionMaster()->Clear();
+
+                std::list<Creature*> cl;
+                me->GetCreaturesWithEntryInRange(cl, 30.0f, 28922);
+                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+
+                cl.clear();
+                me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_CHAMPION);
+                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+
+                cl.clear();
+                me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_NECROMANCER);
+                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+
+                cl.clear();
+                me->GetCreaturesWithEntryInRange(cl, 30.0f, NPC_ANUB_AR_CRYPTFIEND);
+                for (std::list<Creature*>::iterator itr = cl.begin(); itr != cl.end(); ++itr)
+                    (*itr)->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+
+                me->RemoveAurasDueToSpell(SPELL_LEECH_POISON);
+            }
+
+            if ((!who || !who->IsControlledByPlayer()) && me->HealthBelowPct(70))
+            {
+                if (me->HealthBelowPctDamaged(5, damage))
+                    damage = 0;
+                else
+                    damage *= (me->GetHealthPct() - 5.0f) / 65.0f;
+            }
+        }
+
+        bool AnyPlayerBelowWalkTrigger() const
+        {
+            Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+            {
+                Player* player = itr->GetSource();
+                if (!player || player->IsGameMaster())
+                    continue;
+                if (player->GetPositionY() < 625.0f && player->GetPositionZ() > GAUNTLET_END_Z && player->GetPositionZ() < GAUNTLET_START_Z)
+                    return true;
+            }
+            return false;
+        }
+
+        bool AnyPlayerInHadronoxGauntlet() const
+        {
+            Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
+            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+            {
+                Player* player = itr->GetSource();
+                if (!player || player->IsGameMaster())
+                    continue;
+                float z = player->GetPositionZ();
+                float y = player->GetPositionY();
+                if (y < 625.0f && z > GAUNTLET_END_Z)
+                    return true;
+            }
+            return false;
+        }
+
         bool AnyPlayerValid() const
         {
             Map::PlayerList const& playerList = me->GetMap()->GetPlayers();
-            for(Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
+            for (Map::PlayerList::const_iterator itr = playerList.begin(); itr != playerList.end(); ++itr)
                 if (me->GetDistance(itr->GetSource()) < 130.0f && itr->GetSource()->IsAlive() && !itr->GetSource()->IsGameMaster() && me->CanCreatureAttack(itr->GetSource()))
                     return true;
 
             return false;
         }
 
-        void DamageTaken(Unit* who, uint32& damage, DamageEffectType /*damageType*/, SpellSchoolMask /*damageSchoolMask*/) override
-        {
-            if ((!who || !who->IsControlledByPlayer()) && me->HealthBelowPct(70))
-            {
-                if (me->HealthBelowPctDamaged(5, damage))
-                {
-                    damage = 0;
-                }
-                else
-                {
-                    damage *= (me->GetHealthPct() - 5.0f) / 65.0f;
-                }
-            }
-        }
-
         void UpdateAI(uint32 diff) override
         {
-            if (!UpdateVictim())
-                return;
-
             events.Update(diff);
-            if (me->HasUnitState(UNIT_STATE_CASTING))
-                return;
+
+            _movementCheckTimer += diff;
+            if (_movementCheckTimer >= 200)
+            {
+                _movementCheckTimer = 0;
+
+                if (_walkStarted && _currentStep >= 0 && _currentStep < 8)
+                {
+                    const Position& dest = hadronoxWaypoints[_currentStep];
+                    float distToDest = me->GetExactDist(dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ());
+
+                    if (distToDest <= STEP_REACH)
+                    {
+                        _currentStep++;
+                        if (_currentStep < 8)
+                        {
+                            if (_currentStep >= 4)
+                                Talk(SAY_HADRONOX_EMOTE);
+                            MoveToWaypoint(_currentStep);
+                        }
+                    }
+                    else
+                    {
+                        float movedDist = me->GetExactDist(_lastPos.GetPositionX(), _lastPos.GetPositionY(), _lastPos.GetPositionZ());
+                        if (movedDist < 0.1f)
+                            MoveToWaypoint(_currentStep);
+                        _lastPos = me->GetPosition();
+                    }
+                }
+                
+                if (!_walkStarted)
+                {
+                    if (me->GetExactDist(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ()) > 2.0f)
+                        me->GetMotionMaster()->MoveCharge(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ(), STEP_SPEED, 0, nullptr, true);
+
+                    std::list<Creature*> addList;
+                    for (uint32 entry : {(uint32)NPC_ANUB_AR_CRUSHER, (uint32)NPC_ANUB_AR_CHAMPION, (uint32)NPC_ANUB_AR_CRYPTFIEND, (uint32)NPC_ANUB_AR_NECROMANCER})
+                    {
+                        std::list<Creature*> tmp;
+                        me->GetCreaturesWithEntryInRange(tmp, 500.0f, entry);
+                        addList.splice(addList.end(), tmp);
+                    }
+                    for (Creature* add : addList)
+                        if (add->GetExactDist(HADRONOX_SPAWN_POS.GetPositionX(), HADRONOX_SPAWN_POS.GetPositionY(), HADRONOX_SPAWN_POS.GetPositionZ()) > ADDS_RANGE)
+                            add->GetMotionMaster()->MoveChase(me);
+                }
+            }
 
             switch (uint32 eventId = events.ExecuteEvent())
             {
+                case EVENT_HADRONOX_CHECK:
+                    if (me->IsAlive() && instance->IsBossDone(DATA_KRIKTHIR))
+                    {
+                        if (AnyPlayerInHadronoxGauntlet())
+                        {
+                            if (!_crusherAggroSaid)
+                            {
+                                _crusherAggroSaid = true;
+                                if (Creature* crusher = me->FindNearestCreature(NPC_ANUB_AR_CRUSHER, 300.0f, true))
+                                    crusher->AI()->Talk(SAY_CRUSHER_AGGRO);
+                                StartSummonEvents();
+                            }
+                            if (!_walkStarted && AnyPlayerBelowWalkTrigger())
+                                StartWalkEvent();
+                        }
+                        else if (_walkStarted || _combatStarted || instance->GetBossState(DATA_HADRONOX) == IN_PROGRESS)
+                            me->AI()->EnterEvadeMode();
+                    }
+                    events.ScheduleEvent(EVENT_HADRONOX_CHECK, 2s);
+                    break;
+                case EVENT_HADRONOX_STEP:
+                    _currentStep = 0;
+                    MoveToWaypoint(0);
+                    break;
+                case EVENT_HADRONOX_SUMMON_CHAMPION:
+                    SummonAdd(NPC_ANUB_AR_CHAMPION);
+                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CHAMPION, 15s);
+                    break;
+                case EVENT_HADRONOX_SUMMON_NECRO:
+                    SummonAdd(NPC_ANUB_AR_NECROMANCER);
+                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_NECRO, 10s);
+                    break;
+                case EVENT_HADRONOX_SUMMON_CRYPT:
+                    SummonAdd(NPC_ANUB_AR_CRYPTFIEND);
+                    events.ScheduleEvent(EVENT_HADRONOX_SUMMON_CRYPT, 5s);
+                    break;
                 case EVENT_HADRONOX_PIERCE:
-                    me->CastSpell(me->GetVictim(), SPELL_PIERCE_ARMOR, false);
+                    if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
+                        me->CastSpell(me->GetVictim(), SPELL_PIERCE_ARMOR, false);
                     events.ScheduleEvent(EVENT_HADRONOX_PIERCE, 8s);
                     break;
                 case EVENT_HADRONOX_ACID:
-                    if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100, false))
-                        me->CastSpell(target, SPELL_ACID_CLOUD, false);
+                    if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
+                        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100, false))
+                            me->CastSpell(target, SPELL_ACID_CLOUD, false);
                     events.ScheduleEvent(EVENT_HADRONOX_ACID, 25s);
                     break;
                 case EVENT_HADRONOX_LEECH:
-                    me->CastSpell(me, SPELL_LEECH_POISON, false);
+                    if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
+                        me->CastSpell(me, SPELL_LEECH_POISON, false);
                     events.ScheduleEvent(EVENT_HADRONOX_LEECH, 12s);
                     break;
                 case EVENT_HADRONOX_GRAB:
-                    me->CastSpell(me, SPELL_WEB_GRAB, false);
+                    if (UpdateVictim() && !me->HasUnitState(UNIT_STATE_CASTING))
+                        me->CastSpell(me, SPELL_WEB_GRAB, false);
                     events.ScheduleEvent(EVENT_HADRONOX_GRAB, 25s);
                     break;
-                case EVENT_HADRONOX_MOVE4:
-                    me->CastSpell(me, SPELL_WEB_FRONT_DOORS, true);
-                    [[fallthrough]]; /// @todo: Not sure whether the fallthrough was a mistake (forgetting a break) or intended. This should be double-checked.
-                case EVENT_HADRONOX_MOVE1:
-                case EVENT_HADRONOX_MOVE2:
-                case EVENT_HADRONOX_MOVE3:
-                    Talk(SAY_HADRONOX_EMOTE);
-                    me->GetMotionMaster()->MoveCharge(hadronoxSteps[eventId - 1].GetPositionX(), hadronoxSteps[eventId - 1].GetPositionY(), hadronoxSteps[eventId - 1].GetPositionZ(), 10.0f, 0, nullptr, true);
-                    break;
             }
+
+            if (!UpdateVictim())
+                return;
 
             DoMeleeAttackIfReady();
         }
@@ -235,23 +770,20 @@ public:
 
     struct npc_anub_ar_crusherAI : public ScriptedAI
     {
-        npc_anub_ar_crusherAI(Creature* c) : ScriptedAI(c), summons(me) {}
+        npc_anub_ar_crusherAI(Creature* c) : ScriptedAI(c), summons(me)
+        {
+            _eventStarted = false;
+        }
 
         EventMap events;
         SummonList summons;
+        bool _eventStarted;
 
         void Reset() override
         {
             summons.DespawnAll();
             events.Reset();
-
-            if (me->ToTempSummon())
-                if (Unit* summoner = me->ToTempSummon()->GetSummonerUnit())
-                    if (summoner->GetEntry() == me->GetEntry())
-                    {
-                        me->CastSpell(me, RAND(SPELL_SUMMON_ANUBAR_CHAMPION, SPELL_SUMMON_ANUBAR_CRYPT_FIEND, SPELL_SUMMON_ANUBAR_NECROMANCER), true);
-                        me->CastSpell(me, RAND(SPELL_SUMMON_ANUBAR_CHAMPION, SPELL_SUMMON_ANUBAR_CRYPT_FIEND, SPELL_SUMMON_ANUBAR_NECROMANCER), true);
-                    }
+            _eventStarted = false;
         }
 
         void JustSummoned(Creature* summon) override
@@ -264,29 +796,21 @@ public:
             summons.Summon(summon);
         }
 
-        void DoAction(int32 param) override
-        {
-            if (param == ACTION_DESPAWN_ADDS)
-            {
-                summons.DoAction(ACTION_DESPAWN_ADDS);
-                summons.DespawnAll();
-            }
-        }
-
         void JustEngagedWith(Unit*) override
         {
-            if (me->ToTempSummon())
-                if (Unit* summoner = me->ToTempSummon()->GetSummonerUnit())
-                    if (summoner->GetEntry() != me->GetEntry())
-                    {
-                        summoner->GetAI()->DoAction(ACTION_START_EVENT);
-                        me->SummonCreature(NPC_ANUB_AR_CRUSHER, 519.58f, 573.73f, 734.30f, 4.50f);
-                        me->SummonCreature(NPC_ANUB_AR_CRUSHER, 539.38f, 573.25f, 732.20f, 4.738f);
-                        Talk(SAY_CRUSHER_AGGRO);
-                    }
+            if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+                hadronox->AI()->DoAction(ACTION_START_WALK);
 
             events.ScheduleEvent(EVENT_CRUSHER_SMASH, 8s, 0, 0);
             events.ScheduleEvent(EVENT_CHECK_HEALTH, 1s);
+        }
+
+        void EnterEvadeMode(EvadeReason /*why*/) override
+        {
+            if (Creature* hadronox = me->FindNearestCreature(NPC_HADRONOX, 500.0f, true))
+                hadronox->AI()->DoAction(ACTION_CRUSHER_EVADE);
+
+            ScriptedAI::EnterEvadeMode();
         }
 
         void UpdateAI(uint32 diff) override
@@ -323,48 +847,6 @@ public:
     {
         return GetAzjolNerubAI<npc_anub_ar_crusherAI>(creature);
     }
-};
-
-class spell_hadronox_summon_periodic_aura : public AuraScript
-{
-    PrepareAuraScript(spell_hadronox_summon_periodic_aura);
-
-public:
-    spell_hadronox_summon_periodic_aura(uint32 delay, uint32 spellEntry) : _delay(delay), _spellEntry(spellEntry) { }
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_WEB_FRONT_DOORS });
-    }
-
-    void HandlePeriodic(AuraEffect const* /*aurEff*/)
-    {
-        PreventDefaultAction();
-        Unit* owner = GetUnitOwner();
-        if (InstanceScript* instance = owner->GetInstanceScript())
-            if (!instance->IsBossDone(DATA_HADRONOX))
-            {
-                if (!owner->HasAura(SPELL_WEB_FRONT_DOORS))
-                    owner->CastSpell(owner, _spellEntry, true);
-                else if (!instance->IsEncounterInProgress())
-                    owner->RemoveAurasDueToSpell(SPELL_WEB_FRONT_DOORS);
-            }
-    }
-
-    void OnApply(AuraEffect const* auraEffect, AuraEffectHandleModes)
-    {
-        GetAura()->GetEffect(auraEffect->GetEffIndex())->SetPeriodicTimer(_delay);
-    }
-
-    void Register() override
-    {
-        OnEffectPeriodic += AuraEffectPeriodicFn(spell_hadronox_summon_periodic_aura::HandlePeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
-        OnEffectApply += AuraEffectApplyFn(spell_hadronox_summon_periodic_aura::OnApply, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY, AURA_EFFECT_HANDLE_REAL);
-    }
-
-private:
-    uint32 _delay;
-    uint32 _spellEntry;
 };
 
 class spell_hadronox_leech_poison_aura : public AuraScript
@@ -405,13 +887,37 @@ public:
     }
 };
 
+class spell_hadronox_web_grab : public SpellScript
+{
+    PrepareSpellScript(spell_hadronox_web_grab);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        Unit* caster = GetCaster();
+        targets.remove_if([caster](WorldObject* target) -> bool
+        {
+            if (caster->GetExactDist(target) > 40.0f)
+                return true;
+            if (std::abs(caster->GetPositionZ() - target->GetPositionZ()) > 20.0f)
+                return true;
+            return false;
+        });
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hadronox_web_grab::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
 void AddSC_boss_hadronox()
 {
+    new npc_anub_ar_champion();
+    new npc_anub_ar_necromancer();
+    new npc_anub_ar_cryptfiend();
     new boss_hadronox();
     new npc_anub_ar_crusher();
-    RegisterSpellScriptWithArgs(spell_hadronox_summon_periodic_aura, "spell_hadronox_summon_periodic_champion_aura", 15000, SPELL_SUMMON_ANUBAR_CHAMPION);
-    RegisterSpellScriptWithArgs(spell_hadronox_summon_periodic_aura, "spell_hadronox_summon_periodic_necromancer_aura", 10000, SPELL_SUMMON_ANUBAR_NECROMANCER);
-    RegisterSpellScriptWithArgs(spell_hadronox_summon_periodic_aura, "spell_hadronox_summon_periodic_crypt_fiend_aura", 5000, SPELL_SUMMON_ANUBAR_CRYPT_FIEND);
     RegisterSpellScript(spell_hadronox_leech_poison_aura);
+    RegisterSpellScript(spell_hadronox_web_grab);
     new achievement_hadronox_denied();
 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
@@ -238,9 +238,18 @@ struct npc_watcher_base : public ScriptedAI
         });
     }
 
-    void JustEngagedWith(Unit* /*who*/) override
+    void JustEngagedWith(Unit* who) override
     {
         ScheduleSpells();
+
+        std::list<Creature*> minions;
+        me->GetCreatureListWithEntryInGrid(minions, { NPC_WARRIOR, NPC_SKIRMISHER, NPC_SHADOWCASTER }, 6.7f);
+
+        for (Creature* minion : minions)
+        {
+            if (minion->IsAlive() && !minion->IsInCombat())
+                minion->AI()->AttackStart(who);
+        }
     }
 
     void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
@@ -22,7 +22,6 @@
 
 enum Spells
 {
-    SPELL_SUBBOSS_AGGRO_TRIGGER         = 52343,
     SPELL_SWARM                         = 52440,
     SPELL_MIND_FLAY                     = 52586,
     SPELL_CURSE_OF_FATIGUE              = 52592,
@@ -133,7 +132,6 @@ public:
                 else
                 {
                     Talk(SAY_SEND_GROUP);
-                    me->CastCustomSpell(SPELL_SUBBOSS_AGGRO_TRIGGER, SPELLVALUE_MAX_TARGETS, 1, me, true);
                 }
             }
         }
@@ -249,6 +247,49 @@ struct npc_watcher_base : public ScriptedAI
     {
         if (Creature* krikthir = me->GetInstanceScript() ? me->GetMap()->GetCreature(me->GetInstanceScript()->GetGuidData(DATA_KRIKTHIR)) : nullptr)
             krikthir->AI()->DoAction(ACTION_WATCHER_DIED);
+
+        std::list<Creature*> watchers;
+        me->GetCreatureListWithEntryInGrid(watchers, { NPC_WATCHER_NARJIL, NPC_WATCHER_GASHRA, NPC_WATCHER_SILTHIK }, 100.0f);
+
+        Creature* closestWatcher = nullptr;
+        float closestDist = 0.0f;
+
+        for (Creature* watcher : watchers)
+        {
+            if (!watcher->IsAlive())
+                continue;
+
+            float dist = me->GetDistance(watcher);
+            if (!closestWatcher || dist < closestDist)
+            {
+                closestWatcher = watcher;
+                closestDist = dist;
+            }
+        }
+
+        if (closestWatcher)
+        {
+            Player* nearestPlayer = nullptr;
+            float nearestDist = 0.0f;
+
+            Map::PlayerList const& players = closestWatcher->GetMap()->GetPlayers();
+            for (auto const& ref : players)
+            {
+                Player* player = ref.GetSource();
+                if (!player || !player->IsAlive())
+                    continue;
+
+                float dist = closestWatcher->GetDistance(player);
+                if (!nearestPlayer || dist < nearestDist)
+                {
+                    nearestPlayer = player;
+                    nearestDist = dist;
+                }
+            }
+
+            if (nearestPlayer)
+                closestWatcher->AI()->AttackStart(nearestPlayer);
+        }
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
@@ -304,7 +304,22 @@ struct npc_watcher_base : public ScriptedAI
     void UpdateAI(uint32 diff) override
     {
         if (!UpdateVictim())
+        {
+            std::list<Creature*> minions;
+            me->GetCreatureListWithEntryInGrid(minions, { NPC_WARRIOR, NPC_SKIRMISHER, NPC_SHADOWCASTER }, 7.0f);
+
+            for (Creature* minion : minions)
+            {
+                if (minion->IsAlive() && minion->IsInCombat())
+                {
+                    if (Unit* victim = minion->GetVictim())
+                        AttackStart(victim);
+                    break;
+                }
+            }
+
             return;
+        }
 
         scheduler.Update(diff);
         DoMeleeAttackIfReady();

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
@@ -26,7 +26,13 @@ enum Spells
     SPELL_SWARM                         = 52440,
     SPELL_MIND_FLAY                     = 52586,
     SPELL_CURSE_OF_FATIGUE              = 52592,
-    SPELL_FRENZY                        = 28747
+    SPELL_FRENZY                        = 28747,
+
+    SPELL_WEB_WRAP                      = 52086,
+    SPELL_INFECTED_BITE                 = 52469,
+    SPELL_BLINDING_WEBS                 = 52524,
+    SPELL_ENRAGE                        = 52470,
+    SPELL_POISON_SPRAY                  = 52493
 };
 
 enum Npcs
@@ -48,7 +54,7 @@ enum Yells
 
 enum MiscActions
 {
-    ACTION_MINION_ENGAGED               = 1,
+    ACTION_WATCHER_DIED                 = 1,
     GROUP_SWARM                         = 1
 };
 
@@ -63,7 +69,7 @@ public:
         {
             _initTalk = false;
             _canTalk = true;
-            _minionInCombat = false;
+            _watchersDead = 0;
 
             scheduler.SetValidator([this]
             {
@@ -99,7 +105,7 @@ public:
             });
 
             _canTalk = true;
-            _minionInCombat = false;
+            _watchersDead = 0;
         }
 
         void MoveInLineOfSight(Unit* who) override
@@ -116,21 +122,19 @@ public:
 
         void DoAction(int32 actionId) override
         {
-            if (actionId == ACTION_MINION_ENGAGED && !_minionInCombat)
+            if (actionId == ACTION_WATCHER_DIED)
             {
-                _minionInCombat = true;
+                ++_watchersDead;
 
-                for (Seconds const& timer : { 10s, 40s, 70s })
+                if (_watchersDead >= 3)
                 {
-                    me->m_Events.AddEventAtOffset([this] {
-                        me->CastCustomSpell(SPELL_SUBBOSS_AGGRO_TRIGGER, SPELLVALUE_MAX_TARGETS, 1, me, true);
-                        Talk(SAY_SEND_GROUP);
-                    }, timer);
-                }
-
-                me->m_Events.AddEventAtOffset([this] {
                     me->SetInCombatWithZone();
-                }, 100s);
+                }
+                else
+                {
+                    Talk(SAY_SEND_GROUP);
+                    me->CastCustomSpell(SPELL_SUBBOSS_AGGRO_TRIGGER, SPELLVALUE_MAX_TARGETS, 1, me, true);
+                }
             }
         }
 
@@ -145,8 +149,6 @@ public:
         {
             BossAI::JustEngagedWith(who);
             Talk(SAY_AGGRO);
-
-            me->m_Events.KillAllEvents(false);
 
             scheduler.Schedule(8s, 14s, [&](TaskContext context)
             {
@@ -201,7 +203,7 @@ public:
     private:
         bool _initTalk;
         bool _canTalk;
-        bool _minionInCombat;
+        uint8 _watchersDead;
 
         [[nodiscard]] bool IsInFrenzy() const { return me->HasAura(SPELL_FRENZY); }
     };
@@ -228,8 +230,146 @@ public:
     }
 };
 
+struct npc_watcher_base : public ScriptedAI
+{
+    npc_watcher_base(Creature* creature) : ScriptedAI(creature)
+    {
+        scheduler.SetValidator([this]
+        {
+            return !me->HasUnitState(UNIT_STATE_CASTING);
+        });
+    }
+
+    void JustEngagedWith(Unit* /*who*/) override
+    {
+        ScheduleSpells();
+    }
+
+    void JustDied(Unit* /*killer*/) override
+    {
+        if (Creature* krikthir = me->GetInstanceScript() ? me->GetMap()->GetCreature(me->GetInstanceScript()->GetGuidData(DATA_KRIKTHIR)) : nullptr)
+            krikthir->AI()->DoAction(ACTION_WATCHER_DIED);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!UpdateVictim())
+            return;
+
+        scheduler.Update(diff);
+        DoMeleeAttackIfReady();
+    }
+
+    virtual void ScheduleSpells() = 0;
+
+protected:
+    TaskScheduler scheduler;
+};
+
+class npc_watcher_narjil : public CreatureScript
+{
+public:
+    npc_watcher_narjil() : CreatureScript("npc_watcher_narjil") { }
+
+    struct npc_watcher_narjilAI : public npc_watcher_base
+    {
+        npc_watcher_narjilAI(Creature* creature) : npc_watcher_base(creature) { }
+
+        void ScheduleSpells() override
+        {
+            scheduler.Schedule(2s, 6s, [&](TaskContext context)
+            {
+                DoCastAOE(SPELL_BLINDING_WEBS);
+                context.Repeat(15s, 20s);
+            }).Schedule(6s, 15s, [&](TaskContext context)
+            {
+                DoCastRandomTarget(SPELL_WEB_WRAP);
+                context.Repeat(20s, 25s);
+            }).Schedule(4s, 12s, [&](TaskContext context)
+            {
+                DoCastVictim(SPELL_INFECTED_BITE);
+                context.Repeat(9s, 15s);
+            });
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetAzjolNerubAI<npc_watcher_narjilAI>(creature);
+    }
+};
+
+class npc_watcher_gashra : public CreatureScript
+{
+public:
+    npc_watcher_gashra() : CreatureScript("npc_watcher_gashra") { }
+
+    struct npc_watcher_gashraAI : public npc_watcher_base
+    {
+        npc_watcher_gashraAI(Creature* creature) : npc_watcher_base(creature) { }
+
+        void ScheduleSpells() override
+        {
+            scheduler.Schedule(2s, 6s, [&](TaskContext context)
+            {
+                DoCastSelf(SPELL_ENRAGE);
+                context.Repeat(15s, 20s);
+            }).Schedule(6s, 15s, [&](TaskContext context)
+            {
+                DoCastRandomTarget(SPELL_WEB_WRAP);
+                context.Repeat(20s, 25s);
+            }).Schedule(4s, 12s, [&](TaskContext context)
+            {
+                DoCastVictim(SPELL_INFECTED_BITE);
+                context.Repeat(9s, 15s);
+            });
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetAzjolNerubAI<npc_watcher_gashraAI>(creature);
+    }
+};
+
+class npc_watcher_silthik : public CreatureScript
+{
+public:
+    npc_watcher_silthik() : CreatureScript("npc_watcher_silthik") { }
+
+    struct npc_watcher_silthikAI : public npc_watcher_base
+    {
+        npc_watcher_silthikAI(Creature* creature) : npc_watcher_base(creature) { }
+
+        void ScheduleSpells() override
+        {
+            scheduler.Schedule(2s, 6s, [&](TaskContext context)
+            {
+                DoCastAOE(SPELL_POISON_SPRAY);
+                context.Repeat(15s, 20s);
+            }).Schedule(6s, 15s, [&](TaskContext context)
+            {
+                DoCastRandomTarget(SPELL_WEB_WRAP);
+                context.Repeat(20s, 25s);
+            }).Schedule(4s, 12s, [&](TaskContext context)
+            {
+                DoCastVictim(SPELL_INFECTED_BITE);
+                context.Repeat(9s, 15s);
+            });
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetAzjolNerubAI<npc_watcher_silthikAI>(creature);
+    }
+};
+
 void AddSC_boss_krik_thir()
 {
     new boss_krik_thir();
     new achievement_watch_him_die();
+    new npc_watcher_narjil();
+    new npc_watcher_gashra();
+    new npc_watcher_silthik();
 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/instance_azjol_nerub.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/instance_azjol_nerub.cpp
@@ -22,6 +22,9 @@
 #include "SpellScriptLoader.h"
 #include "azjol_nerub.h"
 #include "SpellScript.h"
+#include "DynamicObject.h"
+#include "DynamicObjectScript.h"
+#include "Log.h"
 
 DoorData const doorData[] =
 {
@@ -56,6 +59,9 @@ BossBoundaryData const boundaries =
     { DATA_ANUBARAK_EVENT, new CircleBoundary(Position(550.6178f, 253.5917f), 26.0f) }
 };
 
+constexpr uint32 DYNOBJ_CHECK_INTERVAL_MS = 10000;
+constexpr uint32 DYNOBJ_DESPAWN_AFTER_MS  = 90000;
+
 class instance_azjol_nerub : public InstanceMapScript
 {
 public:
@@ -71,7 +77,11 @@ public:
             LoadDoorData(doorData);
             LoadObjectData(creatureData, nullptr);
             LoadSummonData(summonData);
+            _dynObjCheckTimer = 0;
         };
+
+        uint32 _dynObjCheckTimer;
+        std::unordered_map<ObjectGuid, uint32> _hadronoxDynObjs; // guid -> accumulated age ms
 
         void OnCreatureEvade(Creature* creature) override
         {
@@ -79,11 +89,67 @@ public:
                 if (Creature* krikthir = GetCreature(DATA_KRIKTHIR))
                     krikthir->AI()->EnterEvadeMode();
         }
+
+        void RegisterHadronoxDynObj(ObjectGuid guid)
+        {
+            if (_hadronoxDynObjs.find(guid) == _hadronoxDynObjs.end())
+                _hadronoxDynObjs[guid] = 0;
+        }
+
+        void Update(uint32 diff) override
+        {
+            _dynObjCheckTimer += diff;
+            if (_dynObjCheckTimer < DYNOBJ_CHECK_INTERVAL_MS)
+                return;
+            _dynObjCheckTimer = 0;
+
+            std::vector<ObjectGuid> toErase;
+            for (auto& [guid, ageMs] : _hadronoxDynObjs)
+            {
+                DynamicObject* dynObj = instance->GetDynamicObject(guid);
+                if (!dynObj)
+                {
+                    toErase.push_back(guid);
+                    continue;
+                }
+
+                ageMs += DYNOBJ_CHECK_INTERVAL_MS;
+
+                if (ageMs >= DYNOBJ_DESPAWN_AFTER_MS)
+                {
+                    dynObj->Remove();
+                    toErase.push_back(guid);
+                }
+            }
+
+            for (ObjectGuid const& guid : toErase)
+                _hadronoxDynObjs.erase(guid);
+        }
     };
 
     InstanceScript* GetInstanceScript(InstanceMap* map) const override
     {
         return new instance_azjol_nerub_InstanceScript(map);
+    }
+};
+
+class dynobj_azjol_nerub_hadronox : public DynamicObjectScript
+{
+public:
+    dynobj_azjol_nerub_hadronox() : DynamicObjectScript("dynobj_azjol_nerub_hadronox") { }
+
+    void OnUpdate(DynamicObject* dynobj, uint32 /*diff*/) override
+    {
+        if (dynobj->GetMapId() != MAP_AZJOL_NERUB)
+            return;
+
+        Unit* caster = dynobj->GetCaster();
+        if (!caster || caster->GetEntry() != NPC_HADRONOX)
+            return;
+
+        if (InstanceScript* instance = dynobj->GetInstanceScript())
+            if (auto* azjolInstance = dynamic_cast<instance_azjol_nerub::instance_azjol_nerub_InstanceScript*>(instance))
+                azjolInstance->RegisterHadronoxDynObj(dynobj->GetGUID());
     }
 };
 
@@ -155,6 +221,7 @@ class spell_azjol_drain_power : public SpellScript
 void AddSC_instance_azjol_nerub()
 {
     new instance_azjol_nerub();
+    new dynobj_azjol_nerub_hadronox();
     RegisterSpellScript(spell_azjol_nerub_fixate);
     RegisterSpellScript(spell_azjol_nerub_web_wrap_aura);
     RegisterSpellScript(spell_azjol_drain_power);


### PR DESCRIPTION
Fixes numerous glitches and non-Blizzlike elements in Azjol-Nerub. Most of it is a large Hadronox rewrite due to various bugs on AzerothCore-based servers. Some spaghetti code, I know, but it works.

Sources for changes:

[Krik'thir and Hadronox visuals, including:
- Daisy chaining of Watchers after death, Watcher pack aggro, removal of private servers' outdated timed approach to Watcher and Krik'thir aggro
- Hadronox periodical adds spawning from all three gates, speed of adds, pack positioning and movements](https://www.youtube.com/watch?v=_2lYRNCVDCE.)

- [General speed and mechanics of Hadronox](https://wowpedia.fandom.com/wiki/Hadronox)
- [Confirmation that Hadronox should be skipable if glitching out trash on top, or running past trash](https://www.mmo-champion.com/threads/694875-5man-speed-runs-what-bosses-can-you-skip)
- [Confirmation that Hadronox's gauntlet should encore towards end of Hadronox's tunnel](https://www.wowhead.com/npc=28921/hadronox#comments:id=465543)

- Includes various bugfixes and preventative approaches to stuck mobs in Anub'arak as well, including a dynobject override of Hadronox's acid clouds that lived for far too long by default